### PR TITLE
chore: point workflow integration_branch at main

### DIFF
--- a/workflow.yaml
+++ b/workflow.yaml
@@ -2,8 +2,8 @@
 # Tool-agnostic: any agent (opencode, Claude Code, etc.) can read this file.
 
 git:
-  main_branch: main            # release branch — protected, never worked on directly
-  integration_branch: develop  # PRs target this branch (git-flow)
+  main_branch: main            # release + integration branch — work via feature branch + PR
+  integration_branch: main     # PRs target main; this repo has no separate develop branch
   branch_prefix: feature/
   # Branch naming: if the change is linked to a backlog task with a real Jira
   # key, branches are <prefix><task-id>-<change-name>


### PR DESCRIPTION
`workflow.yaml` declared `integration_branch: develop`, but no `develop` branch has ever existed in this repo — releases, docs, and PRs all land on `main`. Set `integration_branch: main` so the pipeline config matches reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)