### PR TITLE
docs: point README at CAPABILITIES status map

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ Macao)*, PIPL cross-border, or GDPR SCCs — as reference links, never adjudicat
 ## Scope
 
 For HK / GBA home bases under PDPO / PIPL / GBA. Not yet: vector-DB / storage residency, a pre-commit
-hook, CycloneDX / SPDX SBOM export, and optional LLM enrichment. Full roadmap in `CAPABILITIES.md`.
+hook, CycloneDX / SPDX SBOM export, and optional LLM enrichment. Per-capability status — shipped vs.
+next vs. later — is tracked in [`CAPABILITIES.md`](CAPABILITIES.md).
 
 ## Internal endpoints
 


### PR DESCRIPTION
The README's `## Capabilities` section already references every shipped feature accurately; the only stale spot was the trailing pointer calling `CAPABILITIES.md` a "roadmap". Now linked and described as the shipped/next/later status map, matching the v0.10.1 reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)