### PR TITLE
release: v0.11.0 — pre-commit hook + contribution workflow (E4, F4)

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -1,6 +1,6 @@
 # borderlint — Capability Set
 
-> **Status:** shipped — v0.10.1. The full P1 (MVP) and most of P2 are built and tested; the
+> **Status:** shipped — v0.11.0. The full P1 (MVP) and most of P2 are built and tested; the
 > capability map below tracks actual state (✅ shipped · next · later), not the original plan.
 
 ## 1. Purpose
@@ -123,7 +123,7 @@ asserts the classification, and borderlint governs the resulting flows.
 
 ## 5. Capability map
 
-Status: **✅** = shipped (v0.10.1) · **next** = planned next · **later** = deferred. The full P1
+Status: **✅** = shipped (v0.11.0) · **next** = planned next · **later** = deferred. The full P1
 MVP and most of P2 have shipped; the remaining work is re-tiered into next/later below.
 
 ### A. Detection — *find every AI data flow*

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ borderlint scan examples/gba-resident-app \
 Same command in any pipeline. GitHub Actions (composite action):
 
 ```yaml
-- uses: iolairus/borderlint@v0.10.1
+- uses: iolairus/borderlint@v0.11.0
   with: { path: ., policy: residency.json, classification: customer-pii }
 ```
 
@@ -114,7 +114,7 @@ pre-commit — catch a bad flow before it's committed (`.pre-commit-config.yaml`
 
 ```yaml
 - repo: https://github.com/iolairus/borderlint
-  rev: v0.10.1
+  rev: v0.11.0
   hooks:
     - id: borderlint
       args: [--policy, residency.json, --classification, customer-pii]

--- a/borderlint/__init__.py
+++ b/borderlint/__init__.py
@@ -1,3 +1,3 @@
 """borderlint — map and govern where your AI data and traffic flow."""
 
-__version__ = "0.10.1"
+__version__ = "0.11.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "borderlint"
-version = "0.10.1"
+version = "0.11.0"
 description = "Map and govern where your AI data and traffic flow — east-west / APAC lens."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Release v0.11.0. Minor bump (0.10.1 → 0.11.0) for the two new capabilities shipped in #6:

- **E4** — pre-commit hook (`.pre-commit-hooks.yaml`)
- **F4** — contribution workflow (`CONTRIBUTING.md`, KB schema + PR flow)

Also bumps the pinned `rev`/`@` in the README pre-commit and GitHub Action snippets and the shipped-version markers in `CAPABILITIES.md`. Wheel builds as `borderlint-0.11.0`; 72 tests pass.

Tagging `v0.11.0` after merge triggers the PyPI publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)