### PR TITLE
chore(ci): bump actions off deprecated Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: pip install -e ".[dev]"

--- a/.github/workflows/kb-refresh.yml
+++ b/.github/workflows/kb-refresh.yml
@@ -12,8 +12,8 @@ jobs:
   drift:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - id: drift
@@ -21,7 +21,7 @@ jobs:
           python3 scripts/kb_drift.py > gap.txt || true
           echo "count=$(wc -l < gap.txt)" >> "$GITHUB_OUTPUT"
       - if: steps.drift.outputs.count != '0'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ jobs:
       id-token: write  # OIDC token for PyPI Trusted Publishing — no stored secrets
       contents: read   # checkout needs read access (private repo); declaring permissions resets the rest to none
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: pip install build


### PR DESCRIPTION
Clears the Node 20 deprecation warning surfaced by the v0.11.0 release run.

- `actions/checkout@v4` → `@v5`
- `actions/setup-python@v5` → `@v6`
- `actions/github-script@v7` → `@v8` (kb-refresh)

All targets run on Node 24. `pypa/gh-action-pypi-publish@release/v1` left as-is (Docker-based). The `ci` workflow exercises checkout@v5 + setup-python@v6 on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)