### PR TITLE
chore(kb): mark KB reviewed 2026-06-22

### DIFF
--- a/borderlint/data/providers.json
+++ b/borderlint/data/providers.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-06-20",
+  "updated": "2026-06-22",
   "providers": [
     {"id": "openai", "name": "OpenAI", "sdks": ["openai"], "npm": ["openai", "@ai-sdk/openai"], "endpoints": ["api.openai.com"], "jurisdiction": "us"},
     {"id": "anthropic", "name": "Anthropic", "sdks": ["anthropic"], "npm": ["@anthropic-ai/sdk", "@ai-sdk/anthropic"], "endpoints": ["api.anthropic.com"], "jurisdiction": "us"},


### PR DESCRIPTION
Ran `scripts/kb_drift.py` against the litellm upstream and confirmed the current east-west LLM provider coverage is intentional, then bumped `providers.json` `updated` to today so `borderlint --version` and the SBOM `kb_updated` field carry an honest review date.

No provider entries changed. Candidates surfaced but deliberately deferred this pass: `cerebras`, `fireworks_ai`, `deepinfra`, `databricks`, `fal_ai`, `baseten`, `friendliai` (jurisdictions are human-assigned — separate decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)