### PR TITLE
release: v0.12.1 — friendliai jurisdiction fix

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -1,6 +1,6 @@
 # borderlint — Capability Set
 
-> **Status:** shipped — v0.12.0. The full P1 (MVP) and most of P2 are built and tested; the
+> **Status:** shipped — v0.12.1. The full P1 (MVP) and most of P2 are built and tested; the
 > capability map below tracks actual state (✅ shipped · next · later), not the original plan.
 
 ## 1. Purpose
@@ -123,7 +123,7 @@ asserts the classification, and borderlint governs the resulting flows.
 
 ## 5. Capability map
 
-Status: **✅** = shipped (v0.12.0) · **next** = planned next · **later** = deferred. The full P1
+Status: **✅** = shipped (v0.12.1) · **next** = planned next · **later** = deferred. The full P1
 MVP and most of P2 have shipped; the remaining work is re-tiered into next/later below.
 
 ### A. Detection — *find every AI data flow*

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ borderlint scan examples/gba-resident-app \
 Same command in any pipeline. GitHub Actions (composite action):
 
 ```yaml
-- uses: iolairus/borderlint@v0.12.0
+- uses: iolairus/borderlint@v0.12.1
   with: { path: ., policy: residency.json, classification: customer-pii }
 ```
 
@@ -117,7 +117,7 @@ pre-commit — catch a bad flow before it's committed (`.pre-commit-config.yaml`
 
 ```yaml
 - repo: https://github.com/iolairus/borderlint
-  rev: v0.12.0
+  rev: v0.12.1
   hooks:
     - id: borderlint
       args: [--policy, residency.json, --classification, customer-pii]

--- a/borderlint/__init__.py
+++ b/borderlint/__init__.py
@@ -1,3 +1,3 @@
 """borderlint — map and govern where your AI data and traffic flow."""
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "borderlint"
-version = "0.12.0"
+version = "0.12.1"
 description = "Map and govern where your AI data and traffic flow — east-west / APAC lens."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Patch release. Ships the KB correction from #13: **FriendliAI `us` → `unknown`** (multi-region, no documented serverless region). fal stays `us`.

Bumps version files, README `rev`/`@` pins, and CAPABILITIES markers `0.12.0 → 0.12.1`. Wheel builds as `borderlint-0.12.1`; 75 tests pass. Tagging `v0.12.1` after merge triggers the PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)