### PR TITLE
release: v1.0.0

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -1,6 +1,6 @@
 # borderlint — Capability Set
 
-> **Status:** shipped — v0.12.1. The full P1 (MVP) and most of P2 are built and tested; the
+> **Status:** shipped — v1.0.0. The full P1 (MVP) and most of P2 are built and tested; the
 > capability map below tracks actual state (✅ shipped · next · later), not the original plan.
 
 ## 1. Purpose
@@ -123,7 +123,7 @@ asserts the classification, and borderlint governs the resulting flows.
 
 ## 5. Capability map
 
-Status: **✅** = shipped (v0.12.1) · **next** = planned next · **later** = deferred. The full P1
+Status: **✅** = shipped (v1.0.0) · **next** = planned next · **later** = deferred. The full P1
 MVP and most of P2 have shipped; the remaining work is re-tiered into next/later below.
 
 ### A. Detection — *find every AI data flow*

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The same scan renders to a data-flow map grouped by jurisdiction — Mermaid sou
 Same command in any pipeline. GitHub Actions (composite action):
 
 ```yaml
-- uses: iolairus/borderlint@v0.12.1
+- uses: iolairus/borderlint@v1.0.0
   with: { path: ., policy: residency.json, classification: customer-pii }
 ```
 
@@ -123,7 +123,7 @@ pre-commit — catch a bad flow before it's committed (`.pre-commit-config.yaml`
 
 ```yaml
 - repo: https://github.com/iolairus/borderlint
-  rev: v0.12.1
+  rev: v1.0.0
   hooks:
     - id: borderlint
       args: [--policy, residency.json, --classification, customer-pii]

--- a/borderlint/__init__.py
+++ b/borderlint/__init__.py
@@ -1,3 +1,3 @@
 """borderlint — map and govern where your AI data and traffic flow."""
 
-__version__ = "0.12.1"
+__version__ = "1.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "borderlint"
-version = "0.12.1"
+version = "1.0.0"
 description = "Map and govern where your AI data and traffic flow — east-west / APAC lens."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
First stable release. Bump 0.12.1 → 1.0.0 (version files, README pins, CAPABILITIES markers). Wheel builds as `borderlint-1.0.0`; 76 tests pass. Tagging `v1.0.0` after merge triggers the PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)