### PR TITLE
release: v1.0.1 — fix README image for PyPI

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -1,6 +1,6 @@
 # borderlint — Capability Set
 
-> **Status:** shipped — v1.0.0. The full P1 (MVP) and most of P2 are built and tested; the
+> **Status:** shipped — v1.0.1. The full P1 (MVP) and most of P2 are built and tested; the
 > capability map below tracks actual state (✅ shipped · next · later), not the original plan.
 
 ## 1. Purpose
@@ -123,7 +123,7 @@ asserts the classification, and borderlint governs the resulting flows.
 
 ## 5. Capability map
 
-Status: **✅** = shipped (v1.0.0) · **next** = planned next · **later** = deferred. The full P1
+Status: **✅** = shipped (v1.0.1) · **next** = planned next · **later** = deferred. The full P1
 MVP and most of P2 have shipped; the remaining work is re-tiered into next/later below.
 
 ### A. Detection — *find every AI data flow*

--- a/README.md
+++ b/README.md
@@ -103,16 +103,17 @@ borderlint scan examples/gba-resident-app \
 ```
 
 The same scan renders to a data-flow map grouped by jurisdiction — Mermaid source in
-[`dataflow.mmd`](examples/gba-resident-app/dataflow.mmd), rendered to PNG:
+[`dataflow.mmd`](https://github.com/iolairus/borderlint/blob/main/examples/gba-resident-app/dataflow.mmd),
+rendered to PNG:
 
-![borderlint AI data-flow map for the GBA-resident sample app, grouped by jurisdiction](examples/gba-resident-app/dataflow.png)
+![borderlint AI data-flow map for the GBA-resident sample app, grouped by jurisdiction](https://raw.githubusercontent.com/iolairus/borderlint/main/examples/gba-resident-app/dataflow.png)
 
 ## CI
 
 Same command in any pipeline. GitHub Actions (composite action):
 
 ```yaml
-- uses: iolairus/borderlint@v1.0.0
+- uses: iolairus/borderlint@v1.0.1
   with: { path: ., policy: residency.json, classification: customer-pii }
 ```
 
@@ -123,7 +124,7 @@ pre-commit — catch a bad flow before it's committed (`.pre-commit-config.yaml`
 
 ```yaml
 - repo: https://github.com/iolairus/borderlint
-  rev: v1.0.0
+  rev: v1.0.1
   hooks:
     - id: borderlint
       args: [--policy, residency.json, --classification, customer-pii]

--- a/borderlint/__init__.py
+++ b/borderlint/__init__.py
@@ -1,3 +1,3 @@
 """borderlint — map and govern where your AI data and traffic flow."""
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "borderlint"
-version = "1.0.0"
+version = "1.0.1"
 description = "Map and govern where your AI data and traffic flow — east-west / APAC lens."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
PyPI showed a broken data-flow image because the README used a relative path (PyPI can't resolve those and doesn't host images). The repo is now public, so the image and its Mermaid-source link point at absolute URLs on `main`. Patch bump 1.0.0 → 1.0.1 so PyPI re-renders the frozen description.

Verified: built wheel METADATA contains the absolute `raw.githubusercontent.com` URL; no relative path remains. 76 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)