### PR TITLE
release: v1.1.0 — KB expansion + Vertex region resolution

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -1,6 +1,6 @@
 # borderlint — Capability Set
 
-> **Status:** shipped — v1.0.1. The full P1 (MVP) and most of P2 are built and tested; the
+> **Status:** shipped — v1.1.0. The full P1 (MVP) and most of P2 are built and tested; the
 > capability map below tracks actual state (✅ shipped · next · later), not the original plan.
 
 ## 1. Purpose
@@ -123,7 +123,7 @@ asserts the classification, and borderlint governs the resulting flows.
 
 ## 5. Capability map
 
-Status: **✅** = shipped (v1.0.1) · **next** = planned next · **later** = deferred. The full P1
+Status: **✅** = shipped (v1.1.0) · **next** = planned next · **later** = deferred. The full P1
 MVP and most of P2 have shipped; the remaining work is re-tiered into next/later below.
 
 ### A. Detection — *find every AI data flow*

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ rendered to PNG:
 Same command in any pipeline. GitHub Actions (composite action):
 
 ```yaml
-- uses: iolairus/borderlint@v1.0.1
+- uses: iolairus/borderlint@v1.1.0
   with: { path: ., policy: residency.json, classification: customer-pii }
 ```
 
@@ -126,7 +126,7 @@ pre-commit — catch a bad flow before it's committed (`.pre-commit-config.yaml`
 
 ```yaml
 - repo: https://github.com/iolairus/borderlint
-  rev: v1.0.1
+  rev: v1.1.0
   hooks:
     - id: borderlint
       args: [--policy, residency.json, --classification, customer-pii]

--- a/borderlint/__init__.py
+++ b/borderlint/__init__.py
@@ -1,3 +1,3 @@
 """borderlint — map and govern where your AI data and traffic flow."""
 
-__version__ = "1.0.1"
+__version__ = "1.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "borderlint"
-version = "1.0.1"
+version = "1.1.0"
 description = "Map and govern where your AI data and traffic flow — east-west / APAC lens."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Minor release for #20: Google Vertex AI `gcp` region resolution + ~22 new providers (CN/RU/IN/FR/US, routers, ollama) from the #18 drift review. Wheel builds as `borderlint-1.1.0`; 79 tests pass. Tagging `v1.1.0` after merge triggers the PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)