### PR TITLE
release: v1.1.1 — GitHub Marketplace action metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ rendered to PNG:
 Same command in any pipeline. GitHub Actions (composite action):
 
 ```yaml
-- uses: iolairus/borderlint@v1.1.0
+- uses: iolairus/borderlint@v1.1.1
   with: { path: ., policy: residency.json, classification: customer-pii }
 ```
 
@@ -126,7 +126,7 @@ pre-commit — catch a bad flow before it's committed (`.pre-commit-config.yaml`
 
 ```yaml
 - repo: https://github.com/iolairus/borderlint
-  rev: v1.1.0
+  rev: v1.1.1
   hooks:
     - id: borderlint
       args: [--policy, residency.json, --classification, customer-pii]

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,8 @@
-name: borderlint
+name: borderlint AI Data-Residency Lint
 description: Map and govern where your AI data and traffic flow against a residency policy.
+branding:
+  icon: map
+  color: blue
 inputs:
   path:
     description: Path to scan

--- a/borderlint/__init__.py
+++ b/borderlint/__init__.py
@@ -1,3 +1,3 @@
 """borderlint — map and govern where your AI data and traffic flow."""
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "borderlint"
-version = "1.1.0"
+version = "1.1.1"
 description = "Map and govern where your AI data and traffic flow — east-west / APAC lens."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Unblocks publishing the composite action to the GitHub Marketplace.

## What
- `action.yml`: `name` → **borderlint AI Data-Residency Lint** (Marketplace requires a globally unique name; the repo slug stays `borderlint`).
- `action.yml`: add required `branding` (`icon: map`, `color: blue`).
- Version `1.1.0` → `1.1.1` so the `v*` tag trigger publishes a clean PyPI build instead of colliding with the existing 1.1.0 upload.

## Note
`action.yml` is repo-only (not in the wheel), so the PyPI 1.1.1 package is functionally identical to 1.1.0. Tests are unchanged and don't couple to the version string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)