### PR TITLE
docs: add GitHub Marketplace badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # borderlint
 
+[![GitHub Marketplace](https://img.shields.io/badge/Marketplace-borderlint-2188ff?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/borderlint-ai-data-residency-lint)
+
 **Map and govern where your AI data and traffic flow.**
 
 A static, in-CI linter, initially for **HK / GBA entities**: does your AI data stay within the


### PR DESCRIPTION
Adds a Marketplace badge to the README header linking to the published listing (`borderlint-ai-data-residency-lint`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)