### PR TITLE
docs: English-only — fix leftover Spanish connector in opsx-apply

### DIFF
--- a/.claude/commands/opsx-apply.md
+++ b/.claude/commands/opsx-apply.md
@@ -67,7 +67,7 @@ Implement tasks from an OpenSpec change.
    - read workflow.yaml to get the git.work_mode
    - if work_mode is feature ask for the jira-id.
    - if work_mode is feature and I am on main or develop, create the feature branch and change to it. 
-   - Show branch name following rule: feature/<change-name> o feature/<jira-id>-<change-name>
+   - Show branch name following rule: feature/<change-name> or feature/<jira-id>-<change-name>
 
 7. **Implement tasks (loop until done or blocked)**
 


### PR DESCRIPTION
Translates the one remaining Spanish word in the repo: `o` → `or` in `.claude/commands/opsx-apply.md:70`.

Origin: the `.claude/`/`.opencode/` pipeline tooling came from a Spanish-language OpenSpec/opencode template (cf. `workflow.yaml` `content.default_language: es | en`); this connector was missed when the rest was translated. No code or product docs affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)