### PR TITLE
docs: reposition as multi-jurisdiction linter + narrow .claude ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ Thumbs.db
 
 # Local / one-off — tool state and scratch, not shared
 .opsx/
+.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -4,11 +4,14 @@
 
 **Map and govern where your AI data and traffic flow.**
 
-A static, in-CI linter, initially for **HK / GBA entities**: does your AI data stay within the
-jurisdictions your PDPO / PIPL policy allows? borderlint statically scans your repo (**Python and
-TypeScript/JavaScript**) for AI provider usage, resolves each flow to a jurisdiction (ccTLD codes
-plus the `CN-GBA` / `GBA` tokens), and fails the build on any flow outside the allow-list for the
-data class you declare. Western and Chinese providers are treated evenly. **Zero runtime dependencies.**
+A static, in-CI linter for **AI data residency across APAC & EMEA**, with first-class **HK / GBA**
+support: does your AI data stay within the jurisdictions your residency policy allows? borderlint
+statically scans your repo (**Python and TypeScript/JavaScript**) for AI provider usage, resolves each
+flow to a jurisdiction (ccTLD/ISO codes plus the `CN-GBA` / `GBA` tokens), and fails the build on any
+flow outside the allow-list for the data class you declare. Declare a home base — **HK, Macao, the GBA,
+Japan, Korea, Singapore, Australia, the UK, the EU, or Malaysia** — and flagged flows are tagged with
+the matching regime (PDPO, PIPL, APPI, PIPA, PDPA, the Privacy Act, GDPR …) and its cross-border
+reference. Western and Chinese providers are treated evenly. **Zero runtime dependencies.**
 
 ## Use
 


### PR DESCRIPTION
Two small changes:

**1. README repositioning** — borderlint now supports `jp/kr/sg/au/uk/eu/my` home bases alongside HK/GBA (v1.1.3), so the intro no longer reads "initially for HK/GBA entities." It now leads with **AI data residency across APAC & EMEA, with first-class HK/GBA support**, and lists the supported home bases + regimes inline. (Regimes bullet, Scope, and the Policy `home_location` paragraph were already updated in v1.1.3.)

**2. `.gitignore` fix** — the long-dangling `.claude/` ignore was too broad: 28 `.claude/` files are versioned shared tooling (the opsx commands + spec-reviewer that `opsx-init.sh` ships), and a blanket rule would silently untrack future additions. Narrowed to `.claude/settings.local.json` — the actual local file that should be ignored.

Docs/config only; no code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)