### PR TITLE
release: v1.1.4 — refresh PyPI front page (multi-jurisdiction README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ rendered to PNG:
 Same command in any pipeline. GitHub Actions (composite action):
 
 ```yaml
-- uses: iolairus/borderlint@v1.1.3
+- uses: iolairus/borderlint@v1.1.4
   with: { path: ., policy: residency.json, classification: customer-pii }
 ```
 
@@ -140,7 +140,7 @@ pre-commit — catch a bad flow before it's committed (`.pre-commit-config.yaml`
 
 ```yaml
 - repo: https://github.com/iolairus/borderlint
-  rev: v1.1.3
+  rev: v1.1.4
   hooks:
     - id: borderlint
       args: [--policy, residency.json, --classification, customer-pii]

--- a/borderlint/__init__.py
+++ b/borderlint/__init__.py
@@ -1,3 +1,3 @@
 """borderlint — map and govern where your AI data and traffic flow."""
 
-__version__ = "1.1.3"
+__version__ = "1.1.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "borderlint"
-version = "1.1.3"
+version = "1.1.4"
 description = "Map and govern where your AI data and traffic flow — east-west / APAC lens."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Docs-only release. Bumps `1.1.3` → `1.1.4` so the next PyPI publish refreshes the **long_description** (frozen at upload time) with the repositioned README — borderlint as an APAC/EMEA data-residency linter with first-class HK/GBA support, not HK/GBA-only.

Package is functionally identical to 1.1.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)