### PR TITLE
fix(sovereignty): add Canada bloc, correct Cohere, tighten override & unknown-gate (v1.2.1)

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -99,7 +99,7 @@ jurisdiction" — a posture many HK/GBA and EU entities in fact hold.
 
 **Sovereignty blocs.** borderlint models a small set of blocs, not per-country sovereigns:
 `us`, `eu` (the EU/EEA as a single compelled-disclosure unit), `cn`, `uk` (post-Brexit, distinct
-from EU), `ru`, `in`, `il`, `local` (self-hosted — no external sovereign), and `unknown`
+from EU), `ru`, `in`, `il`, `ca`, `local` (self-hosted — no external sovereign), and `unknown`
 (aggregators, custom endpoints, or unmapped providers). Sovereignty is derived from the
 **provider** (its home legal regime), not the endpoint region; region-in-endpoint providers
 (Bedrock, Azure OpenAI, Vertex) inherit the provider's sovereignty regardless of the resolved

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ so `sg` is allowed but `my` is not, matching a PDPO agreed-locations EULA. `GBA`
 **Sovereignty — opt-in, orthogonal to residency.** Residency says *where the bytes rest*;
 **sovereignty** says *which government can compel disclosure* — a US provider (AWS, Azure, GCP,
 OpenAI) is subject to the CLOUD Act regardless of the endpoint region. Add a `sovereignty` block
-to constrain it per class. Bloc vocabulary: `us`, `eu`, `cn`, `uk`, `ru`, `in`, `il`, `local`,
-`unknown`. Absent the block, behaviour is unchanged (sovereignty is reported as a column but never
+to constrain it per class. Bloc vocabulary: `us`, `eu`, `cn`, `uk`, `ru`, `in`, `il`, `ca`,
+`local`, `unknown`. Absent the block, behaviour is unchanged (sovereignty is reported as a column but never
 gates). `local` sovereignty is exempt (self-hosted = no external sovereign). See
 [CAPABILITIES.md §3.1](CAPABILITIES.md) for the full model.
 

--- a/borderlint/__init__.py
+++ b/borderlint/__init__.py
@@ -1,3 +1,3 @@
 """borderlint — map and govern where your AI data and traffic flow."""
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"

--- a/borderlint/data/sovereignty.json
+++ b/borderlint/data/sovereignty.json
@@ -9,6 +9,7 @@
     "ru": "SORM; FSB access under Russian law.",
     "in": "DPDP Act 2023 + IT Act 2000.",
     "il": "Israeli privacy law and surveillance framework.",
+    "ca": "PIPEDA + the CSIS/RCMP production-order regime — Canadian-headquartered providers are subject to Canadian compelled-disclosure process.",
     "local": "Self-hosted inference — no external sovereign; the operator's own jurisdiction governs.",
     "unknown": "Sovereignty not statically determinable (aggregator/router or unmapped host)."
   },
@@ -20,7 +21,7 @@
     "azure_openai": "us",
     "aws_bedrock": "us",
     "mistral": "eu",
-    "cohere": "us",
+    "cohere": "ca",
     "cerebras": "us",
     "fireworks_ai": "us",
     "deepinfra": "us",

--- a/borderlint/kb.py
+++ b/borderlint/kb.py
@@ -82,7 +82,7 @@ def _valid_jurisdiction(token: str) -> bool:
 # --- Sovereignty dimension ----------------------------------------------------
 # Sovereignty blocs: which government can compel disclosure of a flow's data, derived from the
 # provider's home legal regime (not the endpoint region). Distinct from residency.
-_SOVEREIGNTY_BLOCS = frozenset({"us", "eu", "cn", "uk", "ru", "in", "il", "local", "unknown"})
+_SOVEREIGNTY_BLOCS = frozenset({"us", "eu", "cn", "uk", "ru", "in", "il", "ca", "local", "unknown"})
 
 
 def _valid_sovereignty(token: str) -> bool:
@@ -136,7 +136,7 @@ def load_kb(path: str | None = None) -> "KB":
                 if not _valid_sovereignty(bloc):
                     raise ValueError(
                         f"invalid sovereignty bloc '{bloc}' for provider '{pid}' "
-                        "(use one of us, eu, cn, uk, ru, in, il, local, unknown)")
+                        "(use one of us, eu, cn, uk, ru, in, il, ca, local, unknown)")
                 sov_map[pid] = bloc  # user wins
     kb = KB(providers)
     kb.updated = bundled.get("updated")
@@ -192,17 +192,13 @@ class KB:
         if evidence and _is_loopback_evidence(evidence):
             return "local"
         entry = self.by_id.get(provider_id, {})
-        # Host/region-level override (e.g. AWS China regions operated by Sinnet → cn). The
-        # override keys off the resolved jurisdiction, since the region is already encoded there
-        # for region-in-endpoint providers, and off the evidence text for host-token overrides.
+        # Region-level override keyed off the resolved jurisdiction (e.g. AWS China regions,
+        # operated by Sinnet/NWCD, resolve to jurisdiction 'cn' → sovereignty 'cn'). The region
+        # is already encoded in the jurisdiction for region-in-endpoint providers, so an exact
+        # jurisdiction lookup is enough — no substring matching against raw evidence.
         overrides = entry.get("sovereignty_overrides", {})
-        if overrides:
-            if jurisdiction and jurisdiction in overrides:
-                return overrides[jurisdiction]
-            if evidence:
-                for token, bloc in overrides.items():
-                    if token in evidence:
-                        return bloc
+        if jurisdiction and jurisdiction in overrides:
+            return overrides[jurisdiction]
         return self.default_sovereignty(provider_id)
 
     def category(self, pid: str) -> str:

--- a/borderlint/policy.py
+++ b/borderlint/policy.py
@@ -10,7 +10,7 @@ _JURIS_ALIAS = {"uk": "gb"}  # `.uk` is the ccTLD for ISO-3166 `GB`
 
 # Sovereignty bloc vocabulary (mirrors borderlint.kb._SOVEREIGNTY_BLOCS; duplicated here to
 # avoid a circular import — policy must not depend on kb at module load).
-_SOVEREIGNTY_BLOCS = frozenset({"us", "eu", "cn", "uk", "ru", "in", "il", "local", "unknown"})
+_SOVEREIGNTY_BLOCS = frozenset({"us", "eu", "cn", "uk", "ru", "in", "il", "ca", "local", "unknown"})
 
 
 def _valid_sovereignty(token: str) -> bool:
@@ -56,7 +56,7 @@ def load_policy(path: str) -> dict:
                 if not _valid_sovereignty(b):
                     raise ValueError(
                         f"invalid sovereignty bloc '{b}' in classification '{cls}' "
-                        "(use one of us, eu, cn, uk, ru, in, il, local, unknown)")
+                        "(use one of us, eu, cn, uk, ru, in, il, ca, local, unknown)")
     return data
 
 
@@ -120,5 +120,5 @@ def _severity(reasons: list[str], fail_on: set[str], on_unknown: str, sov_on_unk
             or ("residency" in reasons and "residency" in fail_on)
             or ("unknown" in reasons and on_unknown == "fail")
             or ("sovereignty" in reasons and "sovereignty" in fail_on)
-            or ("sovereignty_unknown" in reasons and sov_on_unknown == "fail" and "sovereignty" in fail_on))
+            or ("sovereignty_unknown" in reasons and sov_on_unknown == "fail"))
     return "fail" if fail else "warn"

--- a/borderlint/report.py
+++ b/borderlint/report.py
@@ -26,7 +26,7 @@ REASON = {"denied_provider": "provider denied by policy",
           "sovereignty_unknown": "sovereignty could not be determined"}
 SOVEREIGNTY = {"us": "United States", "eu": "European Union", "cn": "Mainland China",
                "uk": "United Kingdom", "ru": "Russia", "in": "India", "il": "Israel",
-               "local": "Local", "unknown": "Unknown"}
+               "ca": "Canada", "local": "Local", "unknown": "Unknown"}
 _RANK = {"ok": 0, "waived": 1, "warn": 2, "fail": 3}
 
 with open(os.path.join(os.path.dirname(__file__), "data", "arrangements.json"), encoding="utf-8") as _fh:

--- a/openspec/specs/sovereignty/spec.md
+++ b/openspec/specs/sovereignty/spec.md
@@ -24,7 +24,7 @@ endpoint region alone.
 
 ### Requirement: Sovereignty bloc vocabulary
 The system SHALL express sovereignty using the blocs `us`, `eu`, `cn`, `uk`, `ru`, `in`, `il`,
-`local`, and `unknown`. The `eu` bloc represents the EU/EEA as a single compelled-disclosure
+`ca`, `local`, and `unknown`. The `eu` bloc represents the EU/EEA as a single compelled-disclosure
 unit. The `local` bloc represents self-hosted inference with no external sovereign. The `unknown`
 bloc represents a sovereignty that cannot be statically determined. The system SHALL NOT emit any
 sovereignty bloc outside this vocabulary.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "borderlint"
-version = "1.2.0"
+version = "1.2.1"
 description = "Map and govern where your AI data flows — and who can compel its disclosure."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_borderlint.py
+++ b/tests/test_borderlint.py
@@ -758,6 +758,9 @@ def test_sovereignty_resolution():
     assert dets('a = "https://api.sarvam.ai"\n')[0].sovereignty == "in"
     assert dets('a = "https://api.ai21.com"\n')[0].sovereignty == "il"
     assert dets('import mistralai\n')[0].sovereignty == "eu"
+    # Cohere: US endpoint (residency us) but Canadian-headquartered → sovereignty ca (orthogonal)
+    c = dets('import cohere\n')[0]
+    assert c.jurisdiction == "us" and c.sovereignty == "ca"
     # Loopback / self-hosted -> local sovereignty (no external sovereign)
     assert cfg("base_url: http://localhost:8080\n")[0].sovereignty == "local"
     assert dets('import ollama\n')[0].sovereignty == "local"
@@ -772,6 +775,15 @@ def test_sovereignty_host_override():
     assert d.jurisdiction == "cn" and d.sovereignty == "cn"
     d2 = dets('u = "bedrock-runtime.cn-northwest-1.amazonaws.com.cn"\n')[0]
     assert d2.sovereignty == "cn"
+
+
+def test_sovereignty_unknown_fail():
+    # sovereignty.on_unknown: "fail" fails an unknown-sovereignty flow on its own — symmetric with
+    # residency on_unknown, and no longer requires "sovereignty" in fail_on as a second gate.
+    pol = {"classifications": {"customer-pii": ["hk", "CN-GBA", "sg", "us", "gb", "eu", "uk"]},
+           "sovereignty": {"on_unknown": "fail", "classifications": {"customer-pii": ["eu"]}}}
+    f = evaluate([_det("litellm", "unknown", "litellm")], pol, "customer-pii", kb)
+    assert "sovereignty_unknown" in f[0].reasons and f[0].severity == "fail"
 
 
 def test_sovereignty_policy_absent():


### PR DESCRIPTION
## Summary

Three sovereignty corrections surfaced while reviewing #34, shipped as **v1.2.1**.

## What changes

- **New `ca` (Canada) bloc.** Cohere is Toronto-headquartered, so its home compelled-disclosure regime is Canadian (PIPEDA + the CSIS/RCMP production-order framework), not US. The bloc vocabulary had no way to express Canada, so the map fell back to a wrong `us`. Adds `ca` and remaps `cohere` `us` → `ca`. Cohere's US endpoint still resolves to **residency `us`** — a clean illustration of the orthogonality: US bytes, Canadian sovereign.
- **Symmetric unknown-sovereignty gate.** `sovereignty.on_unknown: "fail"` now fails an unknown-sovereignty flow on its own, matching how residency `on_unknown` behaves. Previously it was double-gated — also requiring `sovereignty` in `fail_on` — so a user who set `on_unknown: "fail"` but forgot the `fail_on` entry got silent warns.
- **Tighter override resolution.** `resolve_sovereignty` no longer substring-matches override tokens against raw evidence. Region overrides (AWS China → `cn`) key off the resolved jurisdiction via exact lookup, which is the only real path; the substring branch was dead code and a false-positive footgun for any future two-letter host-token override.

Vocabulary updated consistently across code, `sovereignty.json`, report labels, `README.md`, `CAPABILITIES.md`, and the sovereignty spec.

## Validation

- `pytest` — **97 passed** ✓ (+1 unknown-fail test; Cohere folded into the resolution test)
- Behaviour with no `sovereignty` policy block is unchanged (regression guard intact).

Change: `sovereignty-dimension`