### PR TITLE
chore(release): 1.3.2 — structural-residue milestone

### DIFF
--- a/borderlint/__init__.py
+++ b/borderlint/__init__.py
@@ -1,3 +1,3 @@
 """borderlint — map and govern where your AI data and traffic flow."""
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "borderlint"
-version = "1.3.1"
+version = "1.3.2"
 description = "Map and govern where your AI data flows — and who can compel its disclosure."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
Version bump marking the kb-drift structural-residue milestone (#50): the freshness queue now separates actionable items from acknowledged residue and leads with a one-line summary — issue #39 currently reads "Nothing actionable." Package contents are unchanged from 1.3.1 (the drift tooling lives in `scripts/`, outside the wheel); the release exists as the repo milestone and version marker.

## Verification
- [x] 117 tests pass
- [x] Tag v1.3.2 follows merge; Trusted Publishing handles PyPI