### PR TITLE
chore(release): 1.4.0 — model deny-list + org reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ APP 8) as reference links. (`home_regime` `pdpo`/`pipl` is still accepted.)
   sovereignty `us`, provenance `cn`. Local LLM usage resolves too: GGUF/MLX redistributor repos
   (`TheBloke/…`, `mlx-community/…`), `.gguf` file paths, and Ollama tags (`llama3.2`, `qwen2.5`)
   — so a self-hosted Qwen reads `local`/`local`/`cn`. Opt-in `provenance` policy block, same
-  shape as sovereignty.
+  shape as sovereignty, plus a `deny_models` family ban with provider-deny semantics; findings
+  name the developer organisation when the map knows it.
 - **Policy:** classification-keyed JSON eval-set, deny-by-default, provider allow/deny, configurable
   failure set, declared home regime.
 - **Regimes & arrangements:** declared home location → data-protection regime tag + the cross-border
@@ -191,7 +192,7 @@ rendered to PNG:
 Same command in any pipeline. GitHub Actions (composite action):
 
 ```yaml
-- uses: iolairus/borderlint@v1.3.1
+- uses: iolairus/borderlint@v1.4.0
   with: { path: ., policy: residency.json, classification: customer-pii }
 ```
 
@@ -202,7 +203,7 @@ pre-commit — catch a bad flow before it's committed (`.pre-commit-config.yaml`
 
 ```yaml
 - repo: https://github.com/iolairus/borderlint
-  rev: v1.3.1
+  rev: v1.4.0
   hooks:
     - id: borderlint
       args: [--policy, residency.json, --classification, customer-pii]

--- a/borderlint/__init__.py
+++ b/borderlint/__init__.py
@@ -1,3 +1,3 @@
 """borderlint — map and govern where your AI data and traffic flow."""
 
-__version__ = "1.3.2"
+__version__ = "1.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "borderlint"
-version = "1.3.2"
+version = "1.4.0"
 description = "Map and govern where your AI data flows — and who can compel its disclosure."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
Minor release for the provenance model-family deny-list (#52): `deny_models` bans a family by anchored prefix regardless of serving host or bloc, with the provider-deny semantics (default failure set, waiver-proof, lifted only by an explicit `fail_on` edit) and undodgeable normalization; findings now carry the developer organisation (`model_org`) across text/JSON/SBOM. README refreshed (capability bullet, policy example, CI/pre-commit pins).

## Verification
- [x] 118 tests pass
- [x] Tag v1.4.0 follows merge; Trusted Publishing handles PyPI