### PR TITLE
fix(detect): host-shaped config-endpoint guard + example policy home_location

### DIFF
--- a/borderlint/detect.py
+++ b/borderlint/detect.py
@@ -117,8 +117,8 @@ def _scan_config_endpoints(path: str, src: str, kb) -> list[Detection]:
             continue
         low = host.lower()
         is_loop = low in _LOOPBACK or low.endswith(".localhost")
-        if not is_loop and "." not in host:
-            continue  # bare non-host value (e.g. an enum), skip
+        if not is_loop and not re.search(r"[A-Za-z0-9]\.[A-Za-z0-9]", host):
+            continue  # not host-shaped: bare enums, "." / "./src" (e.g. tsconfig baseUrl), skip
         line = src.count("\n", 0, m.start()) + 1
         if is_loop:
             out.append(Detection("local", "config_endpoint", host, path, line, "local"))

--- a/examples/residency.json
+++ b/examples/residency.json
@@ -1,5 +1,5 @@
 {
-  "home_regime": "pdpo",
+  "home_location": "hk",
   "on_unknown": "warn",
   "fail_on": ["residency", "denied_provider", "sovereignty"],
   "providers": { "deny": [], "allow": [] },

--- a/tests/test_borderlint.py
+++ b/tests/test_borderlint.py
@@ -1438,3 +1438,11 @@ def test_evidence_pack(tmp_path, monkeypatch, capsys):
     assert cli.main(args) == 0
     two = capsys.readouterr().out
     assert one == two and "fail" in one  # byte-identical, records the failing state
+
+
+def test_config_endpoint_ignores_path_values():
+    # tsconfig-style baseUrl values are paths, not endpoints (TellMeWhy false positive)
+    assert cfg('{"compilerOptions": {"baseUrl": "."}}', "tsconfig.json") == []
+    assert cfg('base_url: ./models\n') == []
+    assert cfg('base_url: https://llm-cn.acme.cn/v1\n')[0].provider_id != ""  # real hosts still detected
+    assert cfg("base_url: http://localhost:8080\n")[0].jurisdiction == "local"  # loopback unaffected


### PR DESCRIPTION
## Summary
Two fixes from scanning a real project (TellMeWhy) with 1.5.0:
- `tsconfig.json`'s `baseUrl: "."` was flagged as a config endpoint — the bare-value guard only required a dot, which a literal dot satisfies. The guard now requires a host shape (`alnum.alnum`), skipping path values while real hosts and loopbacks detect unchanged.
- `examples/residency.json` used the legacy `home_regime` key, so evidence packs rendered without the PDPO annex; it now declares `home_location: "hk"`.

## Verification
- [x] 120 tests pass (new: tsconfig/path-value negatives, real-host and loopback positives)
- [x] TellMeWhy re-scan: false positive gone (5 → 4 flows), PDPO annex renders