### PR TITLE
feat(kb): edge_tts and local Whisper runtimes

### DIFF
--- a/borderlint/data/provenance.json
+++ b/borderlint/data/provenance.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-07-05",
+  "updated": "2026-07-08",
   "note": "Advisory only. This map surfaces model-weight provenance — the bloc of the legal regime under which the model's developer operates — matched from model identifiers found statically in code. It does NOT adjudicate whether any export-control regime legally applies; the policy decides. Provenance is distinct from residency (where the endpoint sits) and sovereignty (who can compel disclosure from the serving provider). Fine-tunes and distillations inherit the base family's bloc. Patterns are case-insensitive prefixes anchored at the start of the identifier; longest pattern wins.",
   "sources_note": "Upstream catalogs from which provider prefixes here were derived. Re-check on kb refresh — new open-weights model families appearing on these pages indicate patterns to add. The kb-drift workflow does NOT scrape these automatically; a human diff on a refresh cadence is expected.",
   "sources": {
@@ -240,6 +240,8 @@
   ],
   "provider_defaults_note": "Providers that serve only their own models resolve to the org's bloc when no model reference is bound (two-tier resolution, tier 2). Multi-model hosts (aws_bedrock, vertex_ai, groq, together_ai, ...) and aggregators deliberately have no default.",
   "provider_defaults": {
+    "edge_tts": "us",
+    "whisper_local": "us",
     "openai": "us",
     "anthropic": "us",
     "google_gemini": "us",

--- a/borderlint/data/providers.json
+++ b/borderlint/data/providers.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-07-05",
+  "updated": "2026-07-08",
   "providers": [
     {"id": "openai", "name": "OpenAI", "sdks": ["openai"], "npm": ["openai", "@ai-sdk/openai"], "endpoints": ["api.openai.com"], "jurisdiction": "us"},
     {"id": "anthropic", "name": "Anthropic", "sdks": ["anthropic"], "npm": ["@anthropic-ai/sdk", "@ai-sdk/anthropic"], "endpoints": ["api.anthropic.com"], "jurisdiction": "us"},
@@ -44,6 +44,8 @@
     {"id": "sagemaker", "name": "AWS SageMaker", "sdks": ["sagemaker"], "npm": [], "endpoints": ["runtime.sagemaker"], "jurisdiction": "unknown", "region_scheme": "aws"},
     {"id": "snowflake", "name": "Snowflake Cortex", "sdks": ["snowflake.cortex"], "npm": [], "endpoints": ["snowflakecomputing.com"], "jurisdiction": "unknown", "note": "region is per-account; host does not carry it"},
     {"id": "lemonade", "name": "Lemonade (AMD, local)", "sdks": ["lemonade"], "npm": [], "endpoints": [], "jurisdiction": "local", "note": "local-first inference server (localhost by default)"},
+    {"id": "edge_tts", "name": "Microsoft Edge TTS", "category": "speech", "sdks": ["edge_tts"], "npm": [], "endpoints": ["speech.platform.bing.com"], "jurisdiction": "unknown", "note": "free Edge browser TTS endpoint; serving region undocumented"},
+    {"id": "whisper_local", "name": "Whisper (local)", "category": "speech", "sdks": ["faster_whisper", "whisper"], "npm": [], "endpoints": [], "jurisdiction": "local", "note": "local-first STT runtimes (faster-whisper/CTranslate2, openai-whisper)"},
     {"id": "pinecone", "name": "Pinecone", "category": "vector_store", "sdks": ["pinecone"], "npm": ["@pinecone-database/pinecone"], "endpoints": ["pinecone.io"], "jurisdiction": "unknown", "note": "vector cluster region is chosen per index; not resolvable from the host"},
     {"id": "weaviate", "name": "Weaviate Cloud", "category": "vector_store", "sdks": ["weaviate"], "npm": ["weaviate-client", "weaviate-ts-client"], "endpoints": ["weaviate.cloud", "weaviate.network"], "jurisdiction": "unknown", "note": "cluster region chosen at creation; SDK may also target a self-hosted instance"},
     {"id": "qdrant", "name": "Qdrant Cloud", "category": "vector_store", "sdks": ["qdrant_client"], "npm": ["@qdrant/js-client-rest"], "endpoints": ["qdrant.io"], "jurisdiction": "unknown", "note": "cluster region chosen at creation; SDK may also target a self-hosted instance"},

--- a/borderlint/data/sovereignty.json
+++ b/borderlint/data/sovereignty.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-07-05",
+  "updated": "2026-07-08",
   "note": "Advisory only. This map surfaces compelled-disclosure exposure — which government can compel disclosure of a flow's data via the provider's home legal regime (e.g. US CLOUD Act, PRC DSL/CSL/PIPL). It does NOT adjudicate whether a given statute legally applies to any specific flow; the policy decides. Sovereignty is distinct from residency (where the endpoint physically sits).",
   "sources": {
     "us": "CLOUD Act 2018, FISA 702, Patriot Act §215 — US-headquartered providers subject to US compelled-disclosure process regardless of endpoint region.",
@@ -106,6 +106,8 @@
     "model_reference": "unknown",
     "sagemaker": "us",
     "snowflake": "us",
-    "lemonade": "local"
+    "lemonade": "local",
+    "edge_tts": "us",
+    "whisper_local": "local"
   }
 }

--- a/tests/test_borderlint.py
+++ b/tests/test_borderlint.py
@@ -1446,3 +1446,14 @@ def test_config_endpoint_ignores_path_values():
     assert cfg('base_url: ./models\n') == []
     assert cfg('base_url: https://llm-cn.acme.cn/v1\n')[0].provider_id != ""  # real hosts still detected
     assert cfg("base_url: http://localhost:8080\n")[0].jurisdiction == "local"  # loopback unaffected
+
+
+def test_edge_tts_and_local_whisper():
+    # edge-tts: cross-border speech flow to Microsoft; nested import is caught by the AST walk
+    ds = _scan_file('def speak():\n    import edge_tts\n')
+    d = [x for x in ds if x.provider_id == "edge_tts"][0]
+    assert (d.jurisdiction, d.sovereignty, d.provenance) == ("unknown", "us", "us")
+    # faster-whisper: local runtime, OpenAI-developed weights
+    ds = _scan_file("from faster_whisper import WhisperModel\n")
+    d = [x for x in ds if x.provider_id == "whisper_local"][0]
+    assert (d.jurisdiction, d.sovereignty, d.provenance) == ("local", "local", "us")


### PR DESCRIPTION
## Summary
Two providers surfaced by scanning a real app (TellMeWhy): `edge_tts` — Microsoft's free Edge TTS endpoint, a genuine cross-border speech flow (children's speech text leaving the box), speech category, jurisdiction unknown/sovereignty us/provenance default us — and `whisper_local` — faster-whisper + openai-whisper as an Ollama-style local runtime (local/local, provenance default us: a Whisper runtime serves only OpenAI-developed weights).

## Verification
- [x] 121 tests pass, incl. nested-import detection for edge_tts and the local/local/us triple for faster-whisper
- [x] Live sovereignty-completeness audit covers the new ids (guard test)