### PR TITLE
chore(release): 1.6.0 — packaged-config detection + speech providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ rendered to PNG:
 Same command in any pipeline. GitHub Actions (composite action):
 
 ```yaml
-- uses: iolairus/borderlint@v1.5.0
+- uses: iolairus/borderlint@v1.6.0
   with: { path: ., policy: residency.json, classification: customer-pii }
 ```
 
@@ -207,7 +207,7 @@ pre-commit — catch a bad flow before it's committed (`.pre-commit-config.yaml`
 
 ```yaml
 - repo: https://github.com/iolairus/borderlint
-  rev: v1.5.0
+  rev: v1.6.0
   hooks:
     - id: borderlint
       args: [--policy, residency.json, --classification, customer-pii]

--- a/borderlint/__init__.py
+++ b/borderlint/__init__.py
@@ -1,3 +1,3 @@
 """borderlint — map and govern where your AI data and traffic flow."""
 
-__version__ = "1.5.0"
+__version__ = "1.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "borderlint"
-version = "1.5.0"
+version = "1.6.0"
 description = "Map and govern where your AI data flows — and who can compel its disclosure."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
Minor release bundling the TellMeWhy-driven improvements: env-style AI endpoint keys resolve packaged configs (#57), the config-endpoint guard requires host-shaped values — no more tsconfig noise (#55), `edge_tts` and local Whisper runtimes join the KB (#56), and the example policy exercises the PDPO evidence annex via `home_location` (#55).

## Verification
- [x] 122 tests pass
- [x] Tag v1.6.0 follows merge; Trusted Publishing handles PyPI