### PR TITLE
chore(release): 1.7.0 — local-inference visibility + environment pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ rendered to PNG:
 Same command in any pipeline. GitHub Actions (composite action):
 
 ```yaml
-- uses: iolairus/borderlint@v1.6.0
+- uses: iolairus/borderlint@v1.7.0
   with: { path: ., policy: residency.json, classification: customer-pii }
 ```
 
@@ -207,7 +207,7 @@ pre-commit — catch a bad flow before it's committed (`.pre-commit-config.yaml`
 
 ```yaml
 - repo: https://github.com/iolairus/borderlint
-  rev: v1.6.0
+  rev: v1.7.0
   hooks:
     - id: borderlint
       args: [--policy, residency.json, --classification, customer-pii]

--- a/borderlint/__init__.py
+++ b/borderlint/__init__.py
@@ -1,3 +1,3 @@
 """borderlint — map and govern where your AI data and traffic flow."""
 
-__version__ = "1.6.0"
+__version__ = "1.7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "borderlint"
-version = "1.6.0"
+version = "1.7.0"
 description = "Map and govern where your AI data flows — and who can compel its disclosure."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
Minor release bundling the memorybox-driven fixes: marker-based environment exclusion (#61 — `.venv-cuda`-class dirs pruned by their `pyvenv.cfg`/`conda-meta` artifacts, never traversed), the HF transformers/sentence-transformers local runtime with moondream/florence/clip families (#59), and `.onnx`/`.safetensors` basename matching (#60).

## Verification
- [x] 125 tests pass
- [x] Tag v1.7.0 follows merge; Trusted Publishing handles PyPI