### PR TITLE
chore(release): 1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ rendered to PNG:
 Same command in any pipeline. GitHub Actions (composite action):
 
 ```yaml
-- uses: iolairus/borderlint@v1.7.0
+- uses: iolairus/borderlint@v1.8.0
   with: { path: ., policy: residency.json, classification: customer-pii }
 ```
 
@@ -208,7 +208,7 @@ pre-commit — catch a bad flow before it's committed (`.pre-commit-config.yaml`
 
 ```yaml
 - repo: https://github.com/iolairus/borderlint
-  rev: v1.7.0
+  rev: v1.8.0
   hooks:
     - id: borderlint
       args: [--policy, residency.json, --classification, customer-pii]

--- a/borderlint/__init__.py
+++ b/borderlint/__init__.py
@@ -1,3 +1,3 @@
 """borderlint — map and govern where your AI data and traffic flow."""
 
-__version__ = "1.7.0"
+__version__ = "1.8.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "borderlint"
-version = "1.7.0"
+version = "1.8.0"
 description = "Map and govern where your AI data flows — and who can compel its disclosure."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

v1.8.0 ships the three funnel capabilities merged since 1.7.0:

- **`--format html`** — one self-contained report (no scripts, nothing fetched, injection-safe) for privacy/compliance review; export semantics like sbom/evidence (exit 0). (#63, change `add-html-report-format`)
- **Browsable KB site** at https://iolairus.github.io/borderlint/ — 90 provider pages + 71 model-developer pages generated from the bundled JSON, redeployed on every KB change. (#64, change `add-kb-website`)
- **Agent-integration snippets** for Claude Code and Cursor — the coding agent runs borderlint before adding an AI dependency. (#66, change `add-agent-integrations`)

Version bump + README pins to v1.8.0. Java/Kotlin detection (#67 badge, #68 jvm) intentionally held for the next release pending further real-world validation.

## Verification
- [x] 127 tests green on the release branch
- [x] All three changes spec-reviewed, archived, and in `openspec/specs/`