### PR TITLE
chore(workflow): English-only client-facing content

### DIFF
--- a/.claude/commands/pr-open.md
+++ b/.claude/commands/pr-open.md
@@ -12,7 +12,7 @@ Open a pull/merge request for the change `$ARGUMENTS` (or the one inferred from 
 
 2. Run `/review-change <change>` (spec-reviewer). On REVISE, show findings and stop unless the user overrides.
 
-3. **Language gate (mandatory):** ask with **AskUserQuestion** whether the PR description must be in **castellano** or **English**, preselecting `content.default_language` from `workflow.yaml`.
+3. Write the PR description in **English** (the repo's only content language).
 
 4. Build the PR description from `templates/pr-description.md`, filling it from `proposal.md`, the delta specs, the branch's commit log, and the linked task (frontmatter `change:` match in `backlog/tasks/`).
 

--- a/.claude/commands/req-capture.md
+++ b/.claude/commands/req-capture.md
@@ -8,7 +8,7 @@ Capture requirements for the topic `$ARGUMENTS` through a structured interview, 
 
 1. If no topic was given, ask what problem or initiative we are exploring. Derive a kebab-case topic name.
 
-   **Language gate (mandatory):** before generating any content, ask with **AskUserQuestion** whether the discovery doc must be written in **castellano** or **English**. Preselect `content.default_language` from `workflow.yaml` as the recommended option, but always ask — never assume.
+   The discovery doc is written in **English** (the repo's only content language).
 
 2. Interview the user with the **AskUserQuestion tool**, one round at a time, covering in order:
    - Who are the stakeholders/users affected, and what is the problem today?

--- a/.claude/commands/task-enrich.md
+++ b/.claude/commands/task-enrich.md
@@ -8,7 +8,7 @@ Enrich the task `$ARGUMENTS` (a Jira key like `PROJ-123`, or a path) in `backlog
 
 1. Locate the task file. If the argument is ambiguous or missing, list tasks with `status: draft` and ask.
 
-   **Language gate (mandatory):** if the task has `language:` in its frontmatter, write all additions in that language. If it doesn't, ask with **AskUserQuestion** (castellano or English, preselecting `content.default_language` from `workflow.yaml`) and record it in the frontmatter.
+   All additions are written in **English** (the repo's only content language).
 
 2. Cross-check against `openspec/specs/` and the source discovery doc: does it contradict current behavior? Does it overlap another task?
 

--- a/.claude/commands/task-generate.md
+++ b/.claude/commands/task-generate.md
@@ -8,7 +8,7 @@ Generate tasks from the discovery doc `backlog/discovery/$ARGUMENTS.md` using `t
 
 1. Read the discovery doc. If it doesn't exist, list available ones and ask which to use (or suggest `/req-capture` first).
 
-   **Language gate (mandatory):** ask with **AskUserQuestion** whether the tasks must be written in **castellano** or **English**. Preselect `content.default_language` from `workflow.yaml`, but always ask — these texts end up in front of the client. Record the choice in each task's frontmatter as `language: es|en`.
+   Tasks are written in **English** (the repo's only content language); each task's frontmatter records `language: en`.
 
 2. Read `workflow.yaml` (`jira.project_key`, `backlog.tasks_dir`).
 

--- a/.claude/commands/task-import.md
+++ b/.claude/commands/task-import.md
@@ -12,7 +12,7 @@ Import the existing Jira ticket `$ARGUMENTS` (a real Jira key like `PROJ-123`) i
 
 3. Ask the user to **paste the ticket content**: title, description, acceptance criteria, and any comments worth keeping. Plain text or Jira wiki markup, as-is.
 
-   **Language gate (mandatory):** ask with **AskUserQuestion** whether the task file must be written in **castellano** or **English** — preselect the language of the pasted content if obvious, otherwise `content.default_language` from `workflow.yaml`. Record it in the frontmatter as `language: es|en`.
+   The task file is written in **English** (the repo's only content language) regardless of the pasted ticket's language — translate when needed and record `language: en` in the frontmatter.
 
 4. Normalize the paste into `templates/task.md` — restructure, don't rewrite meaning:
    - Frontmatter: `id` = the real Jira key, `status: draft`, `discovery: ~` (no discovery doc), `priority` only if the ticket states one.

--- a/.claude/commands/task-jira.md
+++ b/.claude/commands/task-jira.md
@@ -8,7 +8,7 @@ Export the task `$ARGUMENTS` (a Jira key like `PROJ-123`, `all`, or a status lik
 
 1. Read `workflow.yaml` (`jira.project_key`, `jira.export_dir`, `jira.default_issue_type`). Resolve which tasks to export from the argument; default to all with `status: enriched`.
 
-   **Language gate (mandatory):** ask with **AskUserQuestion** whether the Jira export must be in **castellano** or **English** — always ask, even if the task has a `language:` in its frontmatter (the Jira project may use a different language). Preselect the task's language or `content.default_language`. If the export language differs from the task's, translate the full content, keeping Gherkin keywords (`Given/When/Then`) in English.
+   Exports are written in **English** (the repo's only content language). If a task was written in another language, translate the full content to English, keeping Gherkin keywords (`Given/When/Then`) as-is.
 
 2. For each task render `backlog/exports/jira/<id>.md` in **Jira wiki markup** (not GitHub markdown):
    - `h2.` headings, `*bold*`, `{code}...{code}` blocks for Gherkin, `||header||` tables, `# / *` lists.

--- a/.claude/commands/task-new.md
+++ b/.claude/commands/task-new.md
@@ -8,7 +8,7 @@ Create one task in `backlog/tasks/` from scratch using `templates/task.md`. `$AR
 
 1. Read `workflow.yaml` (`jira.project_key`, `backlog.tasks_dir`).
 
-   **Language gate (mandatory):** ask with **AskUserQuestion** whether the task must be written in **castellano** or **English**, preselecting `content.default_language`. Record it as `language: es|en`.
+   The task is written in **English** (the repo's only content language); record `language: en`.
 
 2. **Mini interview** — ask only what's needed to fill the template, one round if possible:
    - **Goal**: what must exist or behave differently, and why.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ The pipeline is guided: the user should never have to remember what comes next.
 - Never commit directly to `main` (release branch only). Working on the integration branch is allowed when `git.work_mode: flexible` in `workflow.yaml`; feature branches + PR are still the recommended path when code review matters. With `work_mode: feature`, a feature branch is mandatory.
 - Feature branch naming: `feature/<task id>-<change>` when the change is linked to a backlog task with a real Jira key (e.g. `feature/PROJ-123-speed-up-search`), `feature/<change>` otherwise. When inferring the change from a branch name, strip the leading Jira key.
 - **Branch gate**: no implementation work starts until the working branch is resolved (created and checked out). This applies to `/opsx:apply` and to any ad-hoc code edit. `/git-commit` re-checks at commit time as a safety net, but the gate must run first — don't rely on the net.
-- **Client-facing content language**: any command or agent that generates text exposed to the client (discovery docs, tasks, Jira exports, PR descriptions) MUST ask the user whether to write it in castellano or English before generating — every time, preselecting `content.default_language` from `workflow.yaml`. Never assume the language.
+- **Client-facing content language**: all client-facing text (discovery docs, tasks, Jira exports, PR descriptions) is written in **English** — the repo's only content language (`content.default_language: en` in `workflow.yaml`). Commands do not ask.
 
 ## Repository layout
 

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -28,10 +28,10 @@ jira:
   default_issue_type: Task
 
 content:
-  # Default language offered for client-facing artifacts (discovery docs,
-  # stories, Jira exports, PR descriptions). Commands ALWAYS confirm the
-  # language with the user before generating; this is only the preselected option.
-  default_language: en   # es | en
+  # Language for client-facing artifacts (discovery docs, stories, Jira
+  # exports, PR descriptions). English is the only supported language;
+  # commands write it directly and never ask.
+  default_language: en   # en (only option)
 
 backlog:
   discovery_dir: backlog/discovery


### PR DESCRIPTION
Removes the castellano/English language gate from the pipeline: `workflow.yaml` declares English as the only content language, and AGENTS.md plus all seven pipeline commands write English directly instead of asking every time. No tool behavior changes — config/instructions only.