### PR TITLE
chore(kb-site): rebuild on report.py label changes + weekly self-heal

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,9 +5,12 @@ on:
     paths:
       - "borderlint/data/**"
       - "scripts/kb_site.py"
+      - "borderlint/report.py"  # the generator imports its display labels from here
       - ".github/workflows/pages.yml"
   release:
     types: [published]
+  schedule:
+    - cron: "30 6 * * 1"  # weekly self-heal rebuild, 30 min after kb-refresh
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Follow-up to the weekly-refresh audit: `kb-refresh` is correctly read-only (drift → issue → human curation → KB PR → deploy via paths filter), but two publication gaps existed:

1. **`borderlint/report.py` is a site input but wasn't a trigger** — `kb_site.py` imports `JURIS`/`SOVEREIGNTY`/`_EU` from it (design decision 5 of `add-kb-website`), so a label correction wouldn't redeploy the site.
2. **No self-heal** — a failed or stale deploy had no retry until the next KB change.

Fix: `report.py` added to the `paths:` filter; weekly `schedule` trigger at `30 6 * * 1` (30 minutes after `kb-refresh`). Additive to the kb-website spec's *Automated publication* requirement — the spec lists required triggers and this adds one, changes none.

Workflow-only change; no code, KB, or spec files touched.