### PR TITLE
chore(release): 1.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ rendered to PNG:
 Same command in any pipeline. GitHub Actions (composite action):
 
 ```yaml
-- uses: iolairus/borderlint@v1.9.0
+- uses: iolairus/borderlint@v1.10.0
   with: { path: ., policy: residency.json, classification: customer-pii }
 ```
 
@@ -221,7 +221,7 @@ pre-commit — catch a bad flow before it's committed (`.pre-commit-config.yaml`
 
 ```yaml
 - repo: https://github.com/iolairus/borderlint
-  rev: v1.9.0
+  rev: v1.10.0
   hooks:
     - id: borderlint
       args: [--policy, residency.json, --classification, customer-pii]

--- a/borderlint/__init__.py
+++ b/borderlint/__init__.py
@@ -1,3 +1,3 @@
 """borderlint — map and govern where your AI data and traffic flow."""
 
-__version__ = "1.9.0"
+__version__ = "1.10.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "borderlint"
-version = "1.9.0"
+version = "1.10.0"
 description = "Map and govern where your AI data flows — and who can compel its disclosure."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

v1.10.0 ships the two community-agent features, both spec-reviewed and archived:

- **`borderlint init`** (#65, change `init-policy-wizard`) — interactive wizard scaffolding `residency.json`: home-base and data-class interview, inventory-grounded jurisdiction walk, overwrite guard, non-interactive `--home`/`--classes`. Emits no `fail_on` so the engine defaults (incl. `model_denied`) apply.
- **`--format badge`** (#67, change `add-badge-format`) — shields.io endpoint JSON: green clean / red failures / yellow warn-only / blue inventory (incl. `0 flows`), non-gating export.

Version bump + README pins to v1.10.0.

## Verification
- [x] 141 tests green on the release branch
- [x] Both changes archived; `policy-init` and `badge-output` capabilities in `openspec/specs/`