### PR TITLE
fix(kb): resolve drift review — chirp, muse families, meta route alias

### DIFF
--- a/borderlint/data/provenance.json
+++ b/borderlint/data/provenance.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-07-08",
+  "updated": "2026-07-13",
   "note": "Advisory only. This map surfaces model-weight provenance — the bloc of the legal regime under which the model's developer operates — matched from model identifiers found statically in code. It does NOT adjudicate whether any export-control regime legally applies; the policy decides. Provenance is distinct from residency (where the endpoint sits) and sovereignty (who can compel disclosure from the serving provider). Fine-tunes and distillations inherit the base family's bloc. Patterns are case-insensitive prefixes anchored at the start of the identifier; longest pattern wins.",
   "sources_note": "Upstream catalogs from which provider prefixes here were derived. Re-check on kb refresh — new open-weights model families appearing on these pages indicate patterns to add. The kb-drift workflow does NOT scrape these automatically; a human diff on a refresh cadence is expected.",
   "sources": {
@@ -28,6 +28,8 @@
     "claude-": {"org": "Anthropic", "bloc": "us"},
     "gemini-": {"org": "Google", "bloc": "us"},
     "gemma-": {"org": "Google", "bloc": "us"},
+    "chirp": {"org": "Google", "bloc": "us"},
+    "muse-": {"org": "Meta", "bloc": "us"},
     "grok-": {"org": "xAI", "bloc": "us"},
     "llama-": {"org": "Meta", "bloc": "us"},
     "phi-": {"org": "Microsoft", "bloc": "us"},

--- a/scripts/kb_drift_aliases.json
+++ b/scripts/kb_drift_aliases.json
@@ -32,7 +32,8 @@
     "vertex_ai-text-models": "vertex_ai",
     "vertex_ai-video-models": "vertex_ai",
     "vertex_ai-zai_models": "vertex_ai",
-    "zai": "zhipu"
+    "zai": "zhipu",
+    "meta": "meta_llama"
   },
   "ignore": {
     "apiserpent": "SERP/search API wrapper, no model weights (judged 2026-07-05)",


### PR DESCRIPTION
Clears all three actionable items in #39 (assignments confirmed by the maintainer):

- `chirp` → **Google / us** — Vertex AI speech family (`vertex_ai/chirp_3`)
- `muse-` → **Meta / us** (`meta/muse-spark-1.1`)
- provider `meta` → alias of the covered `meta_llama` in `kb_drift_aliases.json` (litellm route prefix, visible in the muse example id)

`scripts/kb_drift.py` now reports **nothing actionable**; both families resolve via `match_model` (chirp_3 → Google/us, muse-spark-1.1 → Meta/us); 141 tests green. provenance.json review date bumped. Merging redeploys the KB site with the new entries.