### PR TITLE
chore: test dedup + README provider count

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ APP 8) as reference links. (`home_regime` `pdpo`/`pipl` is still accepted.)
   **Microsoft.Extensions.AI** as runtime-routed aggregators),
   plus endpoint references in config/text files (incl. env-style keys like `MYAPP_LLM_SERVER_URL` in `.env`, compose, and settings files) and **OpenAI-compatible `/v1/chat/completions` calls**
   — even to a runtime-configured host (resolved to `unknown`, so `on_unknown: fail` gates it).
-- **Providers:** 90+ across the east-west boundary — OpenAI, Anthropic, Google (Gemini + **Vertex
+- **Providers:** 99 across the east-west boundary — OpenAI, Anthropic, Google (Gemini + **Vertex
   AI**), Azure, Bedrock, Mistral, Cohere, Groq, Together, Perplexity, xAI, Cerebras, Fireworks,
   Replicate, SambaNova, Meta Llama, **AWS SageMaker, Snowflake Cortex** + **Tencent, Alibaba, DeepSeek, Moonshot, Zhipu/Z.ai, Baidu,
   Volcengine, MiniMax**, plus **AI21 (IL), Jina (DE), Voyage, GigaChat (RU), Sarvam (IN), Scaleway &

--- a/tests/test_borderlint.py
+++ b/tests/test_borderlint.py
@@ -1802,39 +1802,6 @@ def test_foundry_and_tokenhub(tmp_path):
     assert ("tencent_tokenhub", "cn") in th
 
 
-def test_kb_site_generator(tmp_path):
-    import importlib.util
-    import json as _json
-    import os
-    import re
-    root = os.path.join(os.path.dirname(__file__), "..")
-    spec = importlib.util.spec_from_file_location("kb_site", os.path.join(root, "scripts", "kb_site.py"))
-    kb_site = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(kb_site)
-    counts = kb_site.build(str(tmp_path))
-    # one page per provider + per developer org + index
-    with open(os.path.join(root, "borderlint", "data", "providers.json"), encoding="utf-8") as fh:
-        n_providers = len(_json.load(fh)["providers"])
-    assert counts["providers"] == n_providers
-    assert counts["orgs"] >= 1
-    assert len(list((tmp_path / "providers").iterdir())) == counts["providers"]
-    assert len(list((tmp_path / "models").iterdir())) == counts["orgs"]  # unique slugs
-    assert (tmp_path / "index.html").exists()
-    # unknown-jurisdiction provider is honest about region-dependence
-    vertex = (tmp_path / "providers" / "vertex_ai.html").read_text()
-    assert "Region-dependent" in vertex
-    # unique title/meta per page, install one-liner everywhere (spot-check two pages)
-    a = (tmp_path / "providers" / "openai.html").read_text()
-    b = (tmp_path / "providers" / "deepseek.html").read_text()
-    for doc in (a, b):
-        assert "pip install borderlint" in doc
-    t = lambda doc: re.search(r"<title>(.*?)</title>", doc).group(1)
-    m = lambda doc: re.search(r'name="description" content="(.*?)"', doc).group(1)
-    assert t(a) != t(b) and m(a) != m(b) and "OpenAI" in t(a)
-    # cn-destination page names its regime and links the arrangement
-    assert 'href="https://' in b and "PIPL" in b
-    # site tooling lives outside the shipped package
-    assert not os.path.exists(os.path.join(root, "borderlint", "kb_site.py"))
 def test_html_report(tmp_path, capsys):
     import json as _json
     from dataclasses import replace


### PR DESCRIPTION
## Summary

Two housekeeping items flagged during the add-csharp-detection and add-aliyun-coverage reviews:

- **Test dedup**: `test_kb_site_generator` was defined twice (merge artifact); the first definition was shadowed and never ran, and ran straight into `test_html_report` with no separator. The identical surviving definition covers everything. Suite count unchanged (146) — confirming the duplicate contributed nothing.
- **README**: provider count updated from "90+" to the exact **99** the KB carries after the Aliyun additions.

No OpenSpec change — no behavior or requirement is touched.

## Verification

- [x] 146 tests pass; exactly one `test_kb_site_generator` definition remains