### PR TITLE
chore(release): 1.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ rendered to PNG:
 Same command in any pipeline. GitHub Actions (composite action):
 
 ```yaml
-- uses: iolairus/borderlint@v1.10.0
+- uses: iolairus/borderlint@v1.11.0
   with: { path: ., policy: residency.json, classification: customer-pii }
 ```
 
@@ -228,7 +228,7 @@ pre-commit — catch a bad flow before it's committed (`.pre-commit-config.yaml`
 
 ```yaml
 - repo: https://github.com/iolairus/borderlint
-  rev: v1.10.0
+  rev: v1.11.0
   hooks:
     - id: borderlint
       args: [--policy, residency.json, --classification, customer-pii]

--- a/borderlint/__init__.py
+++ b/borderlint/__init__.py
@@ -1,3 +1,3 @@
 """borderlint — map and govern where your AI data and traffic flow."""
 
-__version__ = "1.10.0"
+__version__ = "1.11.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "borderlint"
-version = "1.10.0"
+version = "1.11.0"
 description = "Map and govern where your AI data flows — and who can compel its disclosure."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump 1.10.0 → 1.11.0 (pyproject, `__version__`, README action/pre-commit pins). Covers since v1.10.0: C# detection, Aliyun coverage, Claude Code plugin packaging, Huawei ModelArts (MaaS) coverage, drift-resolution fix, docs. Tagging `v1.11.0` after merge triggers the PyPI publish workflow.