### PR TITLE
chore(kb-site-sdk-keys): tick task 6.1

### DIFF
--- a/openspec/changes/archive/2026-07-19-kb-site-sdk-keys/tasks.md
+++ b/openspec/changes/archive/2026-07-19-kb-site-sdk-keys/tasks.md
@@ -27,4 +27,4 @@
 
 ## 6. Deploy
 
-- [ ] 6.1 After merge, confirm the pages workflow republishes (push trigger covers `scripts/kb_site.py` and `borderlint/data/**`); trigger `workflow_dispatch` if the curation landed without touching those paths — kb-website spec: Automated publication
+- [x] 6.1 After merge, confirm the pages workflow republishes (push trigger covers `scripts/kb_site.py` and `borderlint/data/**`); trigger `workflow_dispatch` if the curation landed without touching those paths — kb-website spec: Automated publication


### PR DESCRIPTION
Post-merge confirmation done: pages deploy run [29695233795](https://github.com/iolairus/borderlint/actions/runs/29695233795) succeeded and the live [aws_bedrock page](https://iolairus.github.io/borderlint/providers/aws_bedrock.html) now renders Java/Kotlin/.NET packages. All 11/11 tasks complete.