### PR TITLE
fix(claude-plugin): add version field to plugin.json

### DIFF
--- a/integrations/claude-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "borderlint",
+  "version": "1.0.0",
   "description": "AI data-flow governance for coding agents: run borderlint before adding any AI SDK, endpoint, or model id — residency, sovereignty, and provenance checked in the conversation, before commit.",
   "author": {
     "name": "iolairus"


### PR DESCRIPTION
## What

Adds `"version": "1.0.0"` to `integrations/claude-plugin/.claude-plugin/plugin.json`.

## Why

`claude plugin validate` warns on the missing version field, and `--strict` (which the Anthropic plugin review pipeline may run) turns that warning into a failure — the most likely cause of the catalog submission being silently dropped. With this field, strict validation passes clean:

```
✔ Validation passed
```

The value is static by design: the community catalog pins commit SHAs, so the field never needs to track releases — it only needs to exist.
