### PR TITLE
chore(release): 1.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ rendered to PNG:
 Same command in any pipeline. GitHub Actions (composite action):
 
 ```yaml
-- uses: iolairus/borderlint@v1.11.0
+- uses: iolairus/borderlint@v1.12.0
   with: { path: ., policy: residency.json, classification: customer-pii }
 ```
 
@@ -230,7 +230,7 @@ pre-commit — catch a bad flow before it's committed (`.pre-commit-config.yaml`
 
 ```yaml
 - repo: https://github.com/iolairus/borderlint
-  rev: v1.11.0
+  rev: v1.12.0
   hooks:
     - id: borderlint
       args: [--policy, residency.json, --classification, customer-pii]

--- a/borderlint/__init__.py
+++ b/borderlint/__init__.py
@@ -1,3 +1,3 @@
 """borderlint — map and govern where your AI data and traffic flow."""
 
-__version__ = "1.11.0"
+__version__ = "1.12.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "borderlint"
-version = "1.11.0"
+version = "1.12.0"
 description = "Map and govern where your AI data flows — and who can compel its disclosure."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
Release v1.12.0 — `--explain` lands on PyPI.

## Changes since v1.11.0
- `--explain` flag on `borderlint scan`: plain-language explanation and remediation hint per finding (text: one → line per reason; JSON: an `explanation` field per finding). Deterministic templates, advisory only — exit codes and gating unchanged. (#89)
- Claude plugin: `version` field in plugin.json for strict validation. (#88)
- KB drift report stamped with run date. (#87)

## Version pins
pyproject.toml, borderlint/__init__.py, README action/pre-commit pins → 1.12.0