### PR TITLE
chore(release): 1.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ rendered to PNG:
 Same command in any pipeline. GitHub Actions (composite action):
 
 ```yaml
-- uses: iolairus/borderlint@v1.12.0
+- uses: iolairus/borderlint@v1.13.0
   with: { path: ., policy: residency.json, classification: customer-pii }
 ```
 
@@ -236,7 +236,7 @@ pre-commit — catch a bad flow before it's committed (`.pre-commit-config.yaml`
 
 ```yaml
 - repo: https://github.com/iolairus/borderlint
-  rev: v1.12.0
+  rev: v1.13.0
   hooks:
     - id: borderlint
       args: [--policy, residency.json, --classification, customer-pii]

--- a/borderlint/__init__.py
+++ b/borderlint/__init__.py
@@ -1,3 +1,3 @@
 """borderlint — map and govern where your AI data and traffic flow."""
 
-__version__ = "1.12.0"
+__version__ = "1.13.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "borderlint"
-version = "1.12.0"
+version = "1.13.0"
 description = "Map and govern where your AI data flows — and who can compel its disclosure."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
Release v1.13.0 — MCP config scanning lands on PyPI.

## Changes since v1.12.0
- MCP configuration files (`.mcp.json`, `claude_desktop_config.json`, `.cursor/mcp.json`, `.vscode/mcp.json`) scanned as a first-class detection surface: one `mcp_server` finding per configured server, remote URLs resolved via the provider KB, stdio packages via the new bundled `mcp_servers.json` map, unknowns explicit. Six service providers added to the KB, including Sentry's hosted MCP endpoint found in real-world validation. (#91)

## Version pins
pyproject.toml, borderlint/__init__.py, README action/pre-commit pins → 1.13.0