### PR TITLE
docs(readme): restructure for a clear getting-started path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,62 @@
 # borderlint
 
+[![PyPI](https://img.shields.io/pypi/v/borderlint)](https://pypi.org/project/borderlint/)
 [![GitHub Marketplace](https://img.shields.io/badge/Marketplace-borderlint-2188ff?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/borderlint-ai-data-residency-lint)
 
 **Map and govern where your AI data and traffic flow — who can compel its disclosure, and whose
 model weights it runs.**
 
 A static, in-CI linter for **AI data residency, sovereignty, and model provenance across APAC &
-EMEA**, with first-class **HK / GBA** support. borderlint statically scans your repo (**Python,
-TypeScript/JavaScript, Java/Kotlin, and C#**) for AI provider usage and evaluates each flow against
-three orthogonal dimensions:
+EMEA**, with first-class **HK / GBA** support. Scans **Python, TypeScript/JavaScript, Java/Kotlin,
+C#**, config files, and **MCP server configs**. Zero runtime dependencies.
 
-- **Residency** — *where the bytes rest*. Each flow resolves to a jurisdiction (ccTLD/ISO codes
-  plus the `CN-GBA` / `GBA` tokens); a flow outside the allow-list for the declared data class
-  fails the build.
-- **Sovereignty** — *which government can compel disclosure*. A US-headquartered provider (AWS,
-  Azure, GCP, OpenAI, Anthropic) is subject to the CLOUD Act regardless of the endpoint region;
-  a flow to AWS Bedrock `ap-east-1` is residency-clean for a PDPO policy (residency `hk`) yet
-  remains under **US sovereignty**. An optional `sovereignty` block constrains this per class.
-- **Provenance** — *whose model weights the flow runs*. Model references in code — a Bedrock
-  model ID, a bare API model string, an aggregator-qualified ID, a HF repo, a `.gguf` path, an
-  Ollama tag — resolve to the developer's bloc. Bedrock `ap-east-1` serving DeepSeek-R1 is
-  residency `hk`, sovereignty `us`, **provenance `cn`**; self-hosted Qwen is `local`/`local`/`cn`.
-  An optional `provenance` block constrains this per class.
+## Quick start
 
-Declare a home base — **HK, Macao, the GBA, Japan, Korea, Singapore, Australia, the UK, the EU,
-or Malaysia** — and flagged flows are tagged with the matching regime (PDPO, PIPL, APPI, PIPA,
-PDPA, the Privacy Act, GDPR …) and its cross-border reference. Western and Chinese providers are
-treated evenly. **Zero runtime dependencies.**
+```bash
+pip install borderlint
+
+borderlint scan .        # inventory mode: where does this repo's AI data flow today?
+borderlint init .        # short interview → residency.json, grounded in what the scan found
+borderlint scan . --policy residency.json --classification customer-pii   # now it gates
+```
+
+A violation looks like this (`--explain` adds the arrow lines):
+
+```
+borderlint — AI data-flow & residency report
+==============================================
+[FAIL] DeepSeek -> Mainland China | sovereignty: Mainland China | weights: Mainland China
+        app.py:2 (endpoint_reference: api.deepseek.com)
+           ! jurisdiction outside the allow-list for this data class
+             → DeepSeek resolves to Mainland China, which is not allowed for this data class.
+               Update the policy allow-list or change the provider/endpoint.
+
+Regimes implicated: PIPL
+Reference: PIPL cross-border transfer — Mainland China cross-border PI: CAC security assessment, …
+Summary: 1 fail, 0 warn, 0 waived, 0 ok
+```
+
+Exit code is non-zero on a violation, so the same command gates CI unchanged.
+
+## What it checks
+
+Every detected AI flow is evaluated on three orthogonal axes:
+
+- **Residency** — *where the bytes rest*: each flow resolves to a jurisdiction; outside the
+  allow-list for the declared data class fails the build.
+- **Sovereignty** — *which government can compel disclosure*: a US-headquartered provider is under
+  the CLOUD Act regardless of endpoint region.
+- **Provenance** — *whose model weights the flow runs*: model references resolve to the
+  developer's bloc.
+
+One flow, three different answers: **AWS Bedrock `ap-east-1` serving DeepSeek-R1 is residency
+`hk`, sovereignty `us`, provenance `cn`** — and self-hosted Qwen is `local`/`local`/`cn`. Declare
+a home base (HK, Macao, the GBA, Japan, Korea, Singapore, Australia, the UK, the EU, Malaysia)
+and flagged flows are tagged with the regime in play (PDPO, PIPL, APPI, PIPA, PDPA, the Privacy
+Act, GDPR …) and its cross-border reference. Western and Chinese providers are treated evenly.
+
+Browse the full knowledge base — 100 providers, model developers, regimes — at
+[iolairus.github.io/borderlint](https://iolairus.github.io/borderlint/).
 
 ## Use
 
@@ -35,37 +65,18 @@ python -m borderlint scan ./service --policy residency.json --classification cus
 ```
 
 - No `--policy` → **inventory mode** (lists flows + jurisdictions, exits 0).
-- `--explain` — adds a plain-language explanation and remediation hint under each violation
-  (text: a `→` line per reason; json: an `explanation` field per finding). Advisory only; exit codes unchanged.
-- **MCP configs are scanned too**: `.mcp.json`, `claude_desktop_config.json`, `.cursor/mcp.json`, and
-  `.vscode/mcp.json` are parsed structurally — one finding per configured MCP server (kind `mcp_server`).
-  Remote (`url`) servers resolve their host against the provider KB; stdio servers resolve their package
-  against a bundled MCP-server map (`data/mcp_servers.json`); anything unmapped surfaces as an explicit
-  `unknown`, and purely local servers (filesystem, memory, your own database) as `local`. Claude Desktop's
-  config lives outside your repo — scan it directly: `borderlint scan ~/Library/Application\ Support/Claude/claude_desktop_config.json`.
-- `--format json|mermaid|sarif|sbom|evidence|html|badge` — machine output, a flow map, **SARIF** for GitHub code-scanning,
-  a deterministic **AI data-flow SBOM**, an **evidence pack** — a fileable markdown transfer
-  inventory with an audit envelope (git commit, policy SHA-256, KB review dates), all three
-  governance axes with developer orgs, a waiver register, and a regime annex (PDPO, PIPL + GBA SC,
-  Macao PDPA, PDPA-SG) that fills what the scan proves and leaves marked blanks for what only the
-  organisation knows — an **HTML report**: one self-contained file (no scripts, nothing fetched)
-  to hand your privacy or compliance reviewer; or a **shields.io badge** — a JSON payload for
-  `img.shields.io/endpoint?url=…` showing pass/fail/flow-count on your README or PR. Exports are
-  artifacts, not gates: they exit 0.
+- `--explain` — plain-language explanation and remediation hint under each violation
+  (text: a `→` line per reason; json: an `explanation` field per finding). Advisory only.
+- `--providers internal-endpoints.json` — merge your own endpoint map ([below](#internal-endpoints)).
+- `--format <name>` — see [output formats](#output-formats).
 - `diff <baseline.sbom> <current.sbom>` — compare two SBOMs; **exits 1 when the PR adds a new
-  non-`local` flow** (new egress), else 0. Diff the base-branch SBOM against the PR's to gate new AI egress.
-- `init [path]` — **scaffold a `residency.json`** instead of hand-writing one. It interviews you for
-  a home base (HK, Macao, GBA, JP, KR, SG, AU, UK, EU, MY) and the data classes you handle, runs a
-  read-only inventory scan of `path` (default `.`), then walks each observed jurisdiction and asks
-  whether to keep it for each class — proposing allow-lists grounded in what your code actually
-  reaches. Writes `residency.json` (refuses to overwrite without `--force`). For scripted/CI use,
-  skip the prompts with `--home <seat> --classes <csv>`:
-  ```bash
-  borderlint init . --home hk --classes customer-pii,non-pii --output residency.json
-  ```
+  non-`local` flow** (new egress), else 0.
+- `init [path]` — scaffold `residency.json` via a short interview (or non-interactively:
+  `borderlint init . --home hk --classes customer-pii,non-pii`).
 - Accept a reviewed flow with an inline `# borderlint: allow <reason>` **waiver** (justification
-  required; it's reported as *waived*, not hidden, and can't override an explicit provider `deny`).
-- Exit code is non-zero on a violation, so it gates CI.
+  required; reported as *waived*, not hidden; can't override an explicit provider `deny`).
+- **MCP configs are scanned too**: `.mcp.json`, `claude_desktop_config.json`, and the Cursor /
+  VS Code equivalents — one finding per configured server ([details](#agentic-coding--mcp)).
 
 ## Policy (the eval-set)
 
@@ -101,9 +112,9 @@ so `sg` is allowed but `my` is not, matching a PDPO agreed-locations EULA. `GBA`
 **sovereignty** says *which government can compel disclosure* — a US provider (AWS, Azure, GCP,
 OpenAI) is subject to the CLOUD Act regardless of the endpoint region. Add a `sovereignty` block
 to constrain it per class. Bloc vocabulary: `us`, `eu`, `cn`, `uk`, `ru`, `in`, `il`, `ca`, `jp`,
-`kr`, `sg`, `au`, `ae`, `ch`, `local`, `unknown`. Absent the block, behaviour is unchanged (sovereignty is reported as a column but never
-gates). `local` sovereignty is exempt (self-hosted = no external sovereign). See
-[CAPABILITIES.md §3.1](CAPABILITIES.md) for the full model.
+`kr`, `sg`, `au`, `ae`, `ch`, `local`, `unknown`. Absent the block, behaviour is unchanged
+(sovereignty is reported as a column but never gates). `local` sovereignty is exempt (self-hosted
+= no external sovereign). See [CAPABILITIES.md §3.1](CAPABILITIES.md) for the full model.
 
 **Provenance — opt-in, orthogonal to both.** *Whose model weights* a flow runs, resolved in two
 tiers: a model reference bound to the flow wins; absent one, a provider that serves only its own
@@ -125,66 +136,100 @@ regime** in play and linked to the relevant **cross-border arrangement** (the ma
 Contract variant, PIPL cross-border, GDPR, the UK IDTA, APPI Art. 28, PIPA Art. 28-8, PDPA s.26/s.129,
 APP 8) as reference links. (`home_regime` `pdpo`/`pipl` is still accepted.)
 
-## Capabilities
+## CI
 
-- **Languages:** Python (AST), TypeScript/JavaScript (`import` / `require` / dynamic `import()`),
-  **Java/Kotlin** (`import` / `import static`, incl. **LangChain4j** and **Spring AI** as
-  runtime-routed aggregators and the official OpenAI/Anthropic/Bedrock/Vertex/Azure JVM SDKs),
-  and **C#** (`using` directives incl. `global`/`static`/alias forms — the official
-  OpenAI/Anthropic/Azure/Bedrock/Google .NET SDKs, plus **Semantic Kernel** and
-  **Microsoft.Extensions.AI** as runtime-routed aggregators),
-  plus endpoint references in config/text files (incl. env-style keys like `MYAPP_LLM_SERVER_URL` in `.env`, compose, and settings files) and **OpenAI-compatible `/v1/chat/completions` calls**
-  — even to a runtime-configured host (resolved to `unknown`, so `on_unknown: fail` gates it).
-- **Providers:** 100 across the east-west boundary — OpenAI, Anthropic, Google (Gemini + **Vertex
-  AI**), Azure, Bedrock, Mistral, Cohere, Groq, Together, Perplexity, xAI, Cerebras, Fireworks,
-  Replicate, SambaNova, Meta Llama, **AWS SageMaker, Snowflake Cortex** + **Tencent, Alibaba, DeepSeek, Moonshot, Zhipu/Z.ai, Baidu,
-  Volcengine, MiniMax, Huawei ModelArts**, plus **AI21 (IL), Jina (DE), Voyage, GigaChat (RU), Sarvam (IN), Scaleway &
-  OVHcloud (FR/EU)** and region-selectable clouds (**IBM watsonx, Oracle OCI, Cloudflare Workers AI,
-  Heroku** → `unknown` until you pin a region) — with Python and JS/TS package names and the **Vercel
-  AI SDK** (`@ai-sdk/*`).
-- **Image / video / speech:** generation (**Stability AI, Black Forest Labs/Flux, Runway, Recraft**)
-  and **speech-to-text / TTS** (**ElevenLabs, Deepgram, AssemblyAI, Soniox, Amazon Polly**) — tagged
-  with their `category` and governed for residency like any other flow.
-- **Vector stores (data sinks):** Pinecone, Weaviate Cloud, Qdrant Cloud, Zilliz/Milvus — flagged
-  as `vector_store` and governed for residency (region is per-cluster, so default `unknown`).
-- **Aggregators / routers:** litellm, langchain, LlamaIndex, aisuite, OpenRouter, AI/ML API, Vercel
-  AI core & Gateway → `unknown` (runtime-routed), so `on_unknown: fail` blocks them for sensitive classes.
-- **Jurisdictions:** ccTLD/ISO codes + `CN-GBA` / `GBA`; **AWS / Azure / GCP-Vertex region resolved
-  from the endpoint host** where present (e.g. `bedrock-runtime.ap-east-1…` and
-  `asia-east2-aiplatform.googleapis.com` → `hk`).
-- **Sovereignty:** a per-flow bloc (`us`, `eu`, `cn`, `uk`, `ru`, `in`, `il`, `ca`, `jp`, `kr`,
-  `sg`, `au`, `ae`, `ch`, `local`, `unknown`) derived from the provider's home legal regime — orthogonal to residency. Opt-in
-  policy block; reported in every output format; host-level overrides for ring-fenced
-  subsidiaries (e.g. AWS China / Sinnet → `cn`).
-- **Provenance:** whose model weights a flow runs — a third orthogonal bloc resolved from model
-  references in code (`anthropic.claude-…`, `qwen2.5-72b`, `deepseek/deepseek-r1`, `Qwen/…`,
-  version-pinned `claude-3-5-haiku@20241022`) or
-  the provider's first-party default. Bedrock `ap-east-1` serving DeepSeek-R1 is residency `hk`,
-  sovereignty `us`, provenance `cn`. Local LLM usage resolves too: GGUF/MLX redistributor repos
-  (`TheBloke/…`, `mlx-community/…`), `.gguf` file paths, and Ollama tags (`llama3.2`, `qwen2.5`)
-  — so a self-hosted Qwen reads `local`/`local`/`cn`. Opt-in `provenance` policy block, same
-  shape as sovereignty, plus a `deny_models` family ban with provider-deny semantics; findings
-  name the developer organisation when the map knows it.
-- **Policy:** classification-keyed JSON eval-set, deny-by-default, provider allow/deny, configurable
-  failure set, declared home regime — scaffolded interactively by **`borderlint init`** (or
-  non-interactively with `--home`/`--classes` for CI).
-- **Regimes & arrangements:** declared home location → data-protection regime tag + the cross-border
-  mechanism reference for a flagged flow (context only, never adjudicated). GBA seats `hk`/`mo`/`CN-GBA`
-  → PDPO / Macao PDPA / PIPL + the matching GBA Standard Contract; **APAC/EMEA seats `jp` (APPI), `kr`
-  (PIPA), `sg`/`my` (PDPA s.26 / s.129), `au` (APP 8), `uk` (UK IDTA), `eu` (GDPR)** → their transfer
-  mechanism. PIPL cross-border and GDPR are also surfaced for those destinations.
-- **Output & CI:** text / JSON / Mermaid / SARIF / SBOM / evidence / HTML / badge, an SBOM **`diff`**
-  gate for new egress, inline **waivers**, exit codes, GitHub Action + Jenkins.
-- **Agentic coding:** an installable **Claude Code plugin** (this repo is its own marketplace —
-  `/plugin marketplace add iolairus/borderlint`) and **Cursor** rules that make the agent scan
-  *before* adding an AI dependency, endpoint, or model id.
+Same command in any pipeline. GitHub Actions (composite action):
 
-## Scope
+```yaml
+- uses: iolairus/borderlint@v1.13.0
+  with: { path: ., policy: residency.json, classification: customer-pii }
+```
 
-For HK / CN / GBA / MO plus **JP / KR / SG / AU / UK / EU / MY** home bases (regime tags + cross-border
-references). Not yet: AE / IN / ID (cross-border instruments not yet operational); other jurisdictions;
-CycloneDX / SPDX SBOM export and optional LLM enrichment. Per-capability status — shipped vs. next
-vs. later — is tracked in [`CAPABILITIES.md`](CAPABILITIES.md).
+Jenkins / anything else: `pip install borderlint && borderlint scan . --policy residency.json
+--classification customer-pii` — a non-zero exit fails the stage. Full examples in `examples/ci/`.
+
+pre-commit — catch a bad flow before it's committed (`.pre-commit-config.yaml`):
+
+```yaml
+- repo: https://github.com/iolairus/borderlint
+  rev: v1.13.0
+  hooks:
+    - id: borderlint
+      args: [--policy, residency.json, --classification, customer-pii]
+```
+
+The hook runs `borderlint scan` over the repo (the `args` are required for a real gate; without a
+policy it runs inventory mode and always passes).
+
+## Agentic coding & MCP
+
+The fastest-growing source of unreviewed AI egress is the agent stack itself — the coding agent
+reaching for an SDK, and the MCP servers wired into it.
+
+**MCP config scanning**: `.mcp.json`, `claude_desktop_config.json`, `.cursor/mcp.json`, and
+`.vscode/mcp.json` are parsed structurally — one finding per configured MCP server (kind
+`mcp_server`). Remote (`url`) servers resolve their host against the provider KB; stdio servers
+resolve their package against a bundled MCP-server map (`data/mcp_servers.json`); anything
+unmapped surfaces as an explicit `unknown`, and purely local servers (filesystem, memory, your
+own database) as `local`. Claude Desktop's config lives outside your repo — scan it directly:
+`borderlint scan ~/Library/Application\ Support/Claude/claude_desktop_config.json`.
+
+**Agent integrations**: `integrations/` ships an installable Claude Code plugin and copy-paste
+rules that make the agent run borderlint *before* adding an AI dependency, endpoint, or model id
+— and surface any new non-`local` flow in the conversation, before it is committed:
+
+- **Claude Code** — install the plugin (this repo is its marketplace):
+
+  ```
+  /plugin marketplace add iolairus/borderlint
+  /plugin install borderlint@borderlint
+  ```
+
+  Without plugins: copy
+  [`integrations/claude-plugin/skills/borderlint-check/SKILL.md`](integrations/claude-plugin/skills/borderlint-check/SKILL.md)
+  to `.claude/skills/borderlint-check/SKILL.md`, or append
+  [`integrations/claude-code.md`](integrations/claude-code.md) to your project's
+  `CLAUDE.md` / `AGENTS.md`.
+- **Cursor** — save [`integrations/cursor.mdc`](integrations/cursor.mdc) as
+  `.cursor/rules/borderlint.mdc`.
+
+Advisory by design: the pre-commit hook and the SBOM `diff` gate stay on as the enforcing
+backstop, and accepted flows are recorded with the inline waiver rather than hidden.
+
+## Output formats
+
+| Format | What you get |
+|---|---|
+| `text` (default) | The human-readable report above |
+| `json` | Machine-readable findings, all three axes per flow |
+| `mermaid` | A data-flow map grouped by jurisdiction |
+| `sarif` | SARIF 2.1.0 for GitHub code scanning |
+| `sbom` | A deterministic AI data-flow SBOM (feeds the `diff` gate) |
+| `evidence` | A fileable markdown transfer inventory with audit envelope and regime annex |
+| `html` | One self-contained file to hand your DPO or General Counsel |
+| `badge` | shields.io endpoint JSON: pass/fail/flow-count |
+
+Exports (`sbom`, `evidence`, `html`, `badge`) are artifacts, not gates: they exit 0.
+
+The **evidence pack** carries an audit envelope (git commit, policy SHA-256, KB review dates),
+all three governance axes with developer orgs, a waiver register, and a regime annex (PDPO,
+PIPL + GBA SC, Macao PDPA, PDPA-SG) that fills what the scan proves and leaves marked blanks
+for what only the organisation knows.
+
+The **badge** renders green for clean, red for violations, yellow for warnings, blue for
+inventory mode (flow count):
+
+```json
+{"schemaVersion": 1, "label": "borderlint", "message": "clean", "color": "green"}
+```
+
+Publish it by writing the JSON to any static host (GitHub Pages, a gist) on every push:
+
+```yaml
+- run: borderlint scan . --policy residency.json --classification customer-pii --format badge > badge.json
+```
+
+then reference `https://img.shields.io/endpoint?url=https://your-host/badge.json` in your README.
 
 ## Internal endpoints
 
@@ -220,94 +265,67 @@ rendered to PNG:
 
 ![borderlint AI data-flow map for the GBA-resident sample app, grouped by jurisdiction](https://raw.githubusercontent.com/iolairus/borderlint/main/examples/gba-resident-app/dataflow.png)
 
-## CI
+## Capabilities
 
-Same command in any pipeline. GitHub Actions (composite action):
+- **Languages:** Python (AST), TypeScript/JavaScript (`import` / `require` / dynamic `import()`),
+  **Java/Kotlin** (`import` / `import static`, incl. **LangChain4j** and **Spring AI** as
+  runtime-routed aggregators and the official OpenAI/Anthropic/Bedrock/Vertex/Azure JVM SDKs),
+  and **C#** (`using` directives incl. `global`/`static`/alias forms — the official
+  OpenAI/Anthropic/Azure/Bedrock/Google .NET SDKs, plus **Semantic Kernel** and
+  **Microsoft.Extensions.AI** as runtime-routed aggregators),
+  plus endpoint references in config/text files (incl. env-style keys like `MYAPP_LLM_SERVER_URL` in `.env`, compose, and settings files) and **OpenAI-compatible `/v1/chat/completions` calls**
+  — even to a runtime-configured host (resolved to `unknown`, so `on_unknown: fail` gates it).
+- **Providers:** 100+ across the east-west boundary — OpenAI, Anthropic, Google (Gemini + **Vertex
+  AI**), Azure, Bedrock, Mistral, Cohere, Groq, Together, Perplexity, xAI, Cerebras, Fireworks,
+  Replicate, SambaNova, Meta Llama, **AWS SageMaker, Snowflake Cortex** + **Tencent, Alibaba, DeepSeek, Moonshot, Zhipu/Z.ai, Baidu,
+  Volcengine, MiniMax, Huawei ModelArts**, plus **AI21 (IL), Jina (DE), Voyage, GigaChat (RU), Sarvam (IN), Scaleway &
+  OVHcloud (FR/EU)** and region-selectable clouds (**IBM watsonx, Oracle OCI, Cloudflare Workers AI,
+  Heroku** → `unknown` until you pin a region) — with Python and JS/TS package names and the **Vercel
+  AI SDK** (`@ai-sdk/*`).
+- **MCP configs:** `.mcp.json`, `claude_desktop_config.json`, Cursor / VS Code — one `mcp_server`
+  finding per configured server, resolved via the provider KB and the bundled MCP-server map.
+- **Image / video / speech:** generation (**Stability AI, Black Forest Labs/Flux, Runway, Recraft**)
+  and **speech-to-text / TTS** (**ElevenLabs, Deepgram, AssemblyAI, Soniox, Amazon Polly**) — tagged
+  with their `category` and governed for residency like any other flow.
+- **Vector stores (data sinks):** Pinecone, Weaviate Cloud, Qdrant Cloud, Zilliz/Milvus — flagged
+  as `vector_store` and governed for residency (region is per-cluster, so default `unknown`).
+- **Aggregators / routers:** litellm, langchain, LlamaIndex, aisuite, OpenRouter, AI/ML API, Vercel
+  AI core & Gateway → `unknown` (runtime-routed), so `on_unknown: fail` blocks them for sensitive classes.
+- **Jurisdictions:** ccTLD/ISO codes + `CN-GBA` / `GBA`; **AWS / Azure / GCP-Vertex region resolved
+  from the endpoint host** where present (e.g. `bedrock-runtime.ap-east-1…` and
+  `asia-east2-aiplatform.googleapis.com` → `hk`).
+- **Sovereignty:** a per-flow bloc (`us`, `eu`, `cn`, `uk`, `ru`, `in`, `il`, `ca`, `jp`, `kr`,
+  `sg`, `au`, `ae`, `ch`, `local`, `unknown`) derived from the provider's home legal regime — orthogonal to residency. Opt-in
+  policy block; reported in every output format; host-level overrides for ring-fenced
+  subsidiaries (e.g. AWS China / Sinnet → `cn`).
+- **Provenance:** whose model weights a flow runs — a third orthogonal bloc resolved from model
+  references in code (`anthropic.claude-…`, `qwen2.5-72b`, `deepseek/deepseek-r1`, `Qwen/…`,
+  version-pinned `claude-3-5-haiku@20241022`) or
+  the provider's first-party default. Local LLM usage resolves too: GGUF/MLX redistributor repos
+  (`TheBloke/…`, `mlx-community/…`), `.gguf` file paths, and Ollama tags (`llama3.2`, `qwen2.5`).
+  Opt-in `provenance` policy block, same
+  shape as sovereignty, plus a `deny_models` family ban with provider-deny semantics; findings
+  name the developer organisation when the map knows it.
+- **Policy:** classification-keyed JSON eval-set, deny-by-default, provider allow/deny, configurable
+  failure set, declared home regime — scaffolded interactively by **`borderlint init`** (or
+  non-interactively with `--home`/`--classes` for CI).
+- **Regimes & arrangements:** declared home location → data-protection regime tag + the cross-border
+  mechanism reference for a flagged flow (context only, never adjudicated). GBA seats `hk`/`mo`/`CN-GBA`
+  → PDPO / Macao PDPA / PIPL + the matching GBA Standard Contract; **APAC/EMEA seats `jp` (APPI), `kr`
+  (PIPA), `sg`/`my` (PDPA s.26 / s.129), `au` (APP 8), `uk` (UK IDTA), `eu` (GDPR)** → their transfer
+  mechanism. PIPL cross-border and GDPR are also surfaced for those destinations.
+- **Output & CI:** text / JSON / Mermaid / SARIF / SBOM / evidence / HTML / badge, an SBOM **`diff`**
+  gate for new egress, inline **waivers**, exit codes, GitHub Action + Jenkins.
+- **Agentic coding:** an installable **Claude Code plugin** (this repo is its own marketplace —
+  `/plugin marketplace add iolairus/borderlint`) and **Cursor** rules that make the agent scan
+  *before* adding an AI dependency, endpoint, or model id.
 
-```yaml
-- uses: iolairus/borderlint@v1.13.0
-  with: { path: ., policy: residency.json, classification: customer-pii }
-```
+## Scope
 
-Jenkins / anything else: `pip install borderlint && borderlint scan . --policy residency.json
---classification customer-pii` — a non-zero exit fails the stage. Full examples in `examples/ci/`.
-
-pre-commit — catch a bad flow before it's committed (`.pre-commit-config.yaml`):
-
-```yaml
-- repo: https://github.com/iolairus/borderlint
-  rev: v1.13.0
-  hooks:
-    - id: borderlint
-      args: [--policy, residency.json, --classification, customer-pii]
-```
-
-The hook runs `borderlint scan` over the repo (the `args` are required for a real gate; without a
-policy it runs inventory mode and always passes).
-
-## Agentic coding
-
-The fastest-growing source of unreviewed AI egress is the coding agent itself, reaching for an
-SDK to solve the task in front of it. `integrations/` ships an installable Claude Code plugin
-and copy-paste rules that make the agent run borderlint *before* adding an AI dependency,
-endpoint, or model id — and surface any new non-`local` flow in the conversation, before it is
-committed:
-
-- **Claude Code** — install the plugin (this repo is its marketplace):
-
-  ```
-  /plugin marketplace add iolairus/borderlint
-  /plugin install borderlint@borderlint
-  ```
-
-  Without plugins: copy
-  [`integrations/claude-plugin/skills/borderlint-check/SKILL.md`](integrations/claude-plugin/skills/borderlint-check/SKILL.md)
-  to `.claude/skills/borderlint-check/SKILL.md`, or append
-  [`integrations/claude-code.md`](integrations/claude-code.md) to your project's
-  `CLAUDE.md` / `AGENTS.md`.
-- **Cursor** — save [`integrations/cursor.mdc`](integrations/cursor.mdc) as
-  `.cursor/rules/borderlint.mdc`.
-
-Advisory by design: the pre-commit hook and the SBOM `diff` gate stay on as the enforcing
-backstop, and accepted flows are recorded with the inline waiver rather than hidden.
-
-## Badge
-
-Generate a **shields.io badge** for your README or PR description. The badge shows the scan status
-as a colored badge: green for clean, red for violations, yellow for warnings, blue for inventory
-mode (flow count).
-
-```bash
-borderlint scan . --policy residency.json --classification customer-pii --format badge
-```
-
-Output is JSON conforming to the [shields.io endpoint schema](https://shields.io/endpoint):
-
-```json
-{"schemaVersion": 1, "label": "borderlint", "message": "clean", "color": "green"}
-```
-
-**Policy mode**: message is `"clean"` (green), `"{N} flagged"` (red on failures, yellow on
-warnings only). **Inventory mode** (no `--policy`): message is `"{N} flows"` (blue).
-
-### Publishing to shields.io
-
-Write the badge JSON to a file and host it (GitHub Pages, a gist, or any static host), then
-reference it in your README:
-
-```yaml
-# GitHub Actions — publish badge on every push
-- name: Generate borderlint badge
-  run: borderlint scan . --policy residency.json --classification customer-pii --format badge > badge.json
-- name: Deploy badge
-  run: cp badge.json $GITHUB_PAGES_DIR/badge.json
-```
-
-```markdown
-![borderlint](https://img.shields.io/endpoint?url=https://your-host/badge.json)
-```
-
-Badge output is a non-gating export: it always exits 0 regardless of violations.
+For HK / CN / GBA / MO plus **JP / KR / SG / AU / UK / EU / MY** home bases (regime tags + cross-border
+references). Not yet: AE / IN / ID (cross-border instruments not yet operational); other jurisdictions;
+CycloneDX / SPDX SBOM export and optional LLM enrichment. Per-capability status — shipped vs. next
+vs. later — is tracked in [`CAPABILITIES.md`](CAPABILITIES.md).
 
 ## Keeping the KB fresh
 
@@ -352,6 +370,7 @@ The AI coding agents used to build borderlint, scored on borderlint's own three 
 | GLM 5.2 | OpenRouter → z.ai | `cn` | `cn` (+ `us` exposure at the router hop) | `cn` (Zhipu) |
 | Hunyuan 3 | OpenRouter → Novita AI | `unknown` | `us` (Novita, San Mateo; + router hop) | `cn` (Tencent) |
 | Muse-Glimmer 30B | local, self-hosted | `hk` - My desk, Hong Kong, China | `local` | `us` (Meta) |
+
 ## License
 
 MIT © 2026 Iolaire McKinnon. Vendor-neutral by design.


### PR DESCRIPTION
## Summary
The README had grown feature-by-feature until `pip install` first appeared at line 232, inside the CI section, and a newcomer met ~30 lines of jurisdictional taxonomy before the first runnable command. This restructures it around the adoption path; no content removed, no behavior touched.

## Changes
- **Quick start leads**: install → `scan .` (inventory, zero config) → `init .` → gated scan, with real captured output showing a `[FAIL]` and an `--explain` line.
- Three-axes explainer compressed to one screen, keeping a single DeepSeek-on-Bedrock example; KB site linked for depth.
- `--format` mega-bullet → table; badge publishing folded under Output formats.
- MCP scanning detail merged with Agentic coding into one section.
- Reference material (Capabilities, Scope, KB freshness, Development) moved below the adoption path; PyPI badge added.
- Section order: Quick start → What it checks → Use → Policy → CI → Agents/MCP → Formats → Internal endpoints → reference.