### PR TITLE
chore(release): 1.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ APP 8) as reference links. (`home_regime` `pdpo`/`pipl` is still accepted.)
 Same command in any pipeline. GitHub Actions (composite action):
 
 ```yaml
-- uses: iolairus/borderlint@v1.13.0
+- uses: iolairus/borderlint@v1.14.0
   with: { path: ., policy: residency.json, classification: customer-pii }
 ```
 
@@ -152,7 +152,7 @@ pre-commit — catch a bad flow before it's committed (`.pre-commit-config.yaml`
 
 ```yaml
 - repo: https://github.com/iolairus/borderlint
-  rev: v1.13.0
+  rev: v1.14.0
   hooks:
     - id: borderlint
       args: [--policy, residency.json, --classification, customer-pii]

--- a/borderlint/__init__.py
+++ b/borderlint/__init__.py
@@ -1,3 +1,3 @@
 """borderlint — map and govern where your AI data and traffic flow."""
 
-__version__ = "1.13.0"
+__version__ = "1.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "borderlint"
-version = "1.13.0"
+version = "1.14.0"
 description = "Map and govern where your AI data flows — and who can compel its disclosure."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
Release v1.14.0 — the Suricata egress ruleset lands on PyPI.

## Changes since v1.13.0
- `--format suricata`: compiles the provider KB and residency policy into a TLS-SNI alert ruleset — per-host selection against the expanded allow-list, region-scheme providers always alert (region-dependent), inventory mode covers every KB endpoint. Deterministic sids, non-gating export. Validated 110/110 in Suricata 8.0.6. (#94)
- README restructured around a getting-started path: quick start with real output leads, formats table, reference material moved below. (#93)

## Version pins
pyproject.toml, borderlint/__init__.py, README action/pre-commit pins → 1.14.0