### PR TITLE
feat(kb): provider data-practice facts with citations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,37 @@ covered provider, or not an AI model provider at all, is recorded in
 `scripts/kb_drift_aliases.json` (with a reason for ignores) instead of the KB — same PR workflow,
 read only by the drift check.
 
+## Data-practice facts (`data_practices.json`)
+
+A separate, hand-curated KB answering the four questions privacy reviewers ask first:
+does the provider train on customer API data by default, what is the retention window for
+API inputs/outputs, where is the subprocessor list, and does an enterprise tier change the
+answers. Strictly advisory — it never influences verdicts or exit codes.
+
+Entry schema (one entry per provider id in `providers.json`):
+
+| Field | Required | Meaning |
+|---|---|---|
+| `training_default` | no | `"yes"` \| `"no"` \| `"opt-out"`; omit (JSON `null`) when undocumented |
+| `retention` | no | Free-text retention window for API inputs/outputs; conditions belong in the text |
+| `subprocessors` | no | `{url, locator, retrieved}` link to the provider's subprocessor list |
+| `enterprise_tier` | no | Free-text note on whether an enterprise/commercial tier changes the answers |
+| `reviewed` | yes | ISO-8601 date you last verified every fact in the entry |
+| `citations` | per fact | `{url, locator, retrieved}` for each non-null fact |
+
+Curation rules:
+
+- **Every fact needs a citation**: the source URL, a locator note naming where in the source
+  the statement is made, and the date you retrieved it. Read the primary documentation — never
+  copy from third-party summaries.
+- **Unknown means null.** If a fact isn't publicly documented, leave it `null`; the renderers
+  state "not curated" rather than guessing.
+- **Human curation only.** The drift check reports providers without entries and entries whose
+  `reviewed` date exceeds the 90-day interval — ids only, never proposed values. Facts are
+  never auto-filled from upstream feeds. A provider deliberately left uncurated gets a reasoned
+  entry under `data_practices_exempt` in `scripts/kb_drift_aliases.json`.
+- Facts are statements about documented practices as of their retrieval dates — not legal advice.
+
 ## Custom / private providers (no PR needed)
 
 To add providers for your own org without contributing them upstream, pass a user KB with

--- a/borderlint/data/data_practices.json
+++ b/borderlint/data/data_practices.json
@@ -1,0 +1,137 @@
+{
+  "updated": "2026-08-21",
+  "note": "Advisory only. Hand-curated statements about providers' publicly documented data practices (training on customer API data, retention windows, subprocessor lists, enterprise-tier deltas) as of each fact's retrieval date. Never legal advice; never auto-filled from upstream feeds; never influences verdicts. Each entry carries its own 'reviewed' date; undocumented facts are recorded as null (explicitly unknown), never guessed.",
+  "schema": {
+    "entry": {
+      "training_default": "yes | no | opt-out | null (whether the provider trains on customer API data by default)",
+      "retention": "free-text retention window for API inputs/outputs, or null when not publicly documented",
+      "subprocessors": "{url, locator, retrieved} link to the subprocessor list, or null when none found",
+      "enterprise_tier": "free-text note on whether an enterprise/commercial tier changes the answers, or null",
+      "reviewed": "ISO-8601 date this entry was last human-reviewed",
+      "citations": "per-fact {url, locator, retrieved}; every non-null fact MUST carry one"
+    }
+  },
+  "entries": {
+    "openai": {
+      "training_default": "no",
+      "retention": "Abuse-monitoring logs retained up to 30 days by default; application state varies by endpoint (Responses API stores 30 days when store=true; some endpoints until deleted). Zero Data Retention or Modified Abuse Monitoring excludes customer content from abuse logs for approved customers.",
+      "subprocessors": {
+        "url": "https://openai.com/policies/sub-processor-list/",
+        "locator": "Linked from the data controls guide ('OpenAI uses sub-processors to provide its services')",
+        "retrieved": "2026-08-21"
+      },
+      "enterprise_tier": "Zero Data Retention and Modified Abuse Monitoring are subject to prior approval by OpenAI and acceptance of additional requirements (contact sales); Enterprise Key Management (BYOK) is available for application state.",
+      "reviewed": "2026-08-21",
+      "citations": {
+        "training_default": {
+          "url": "https://developers.openai.com/api/docs/guides/your-data",
+          "locator": "'As of March 1, 2023, data sent to the OpenAI API is not used to train or improve OpenAI models (unless you explicitly opt in)'; per-endpoint table shows 'Data used for training: No'",
+          "retrieved": "2026-08-21"
+        },
+        "retention": {
+          "url": "https://developers.openai.com/api/docs/guides/your-data",
+          "locator": "'Abuse monitoring logs ... retained for up to 30 days' and per-endpoint 'Storage requirements and retention controls' table",
+          "retrieved": "2026-08-21"
+        },
+        "enterprise_tier": {
+          "url": "https://developers.openai.com/api/docs/guides/your-data",
+          "locator": "'Currently, these controls are subject to prior approval by OpenAI and acceptance of additional requirements'; Enterprise Key Management (EKM) section",
+          "retrieved": "2026-08-21"
+        }
+      }
+    },
+    "anthropic": {
+      "training_default": "no",
+      "retention": null,
+      "subprocessors": {
+        "url": "https://www.anthropic.com/legal/data-processing-addendum",
+        "locator": "Commercial Terms of Service section C routes data processing through the DPA (which governs subprocessors); no standalone public subprocessor page was reachable at review time",
+        "retrieved": "2026-08-21"
+      },
+      "enterprise_tier": null,
+      "reviewed": "2026-08-21",
+      "citations": {
+        "training_default": {
+          "url": "https://www.anthropic.com/legal/commercial-terms",
+          "locator": "Section B (Customer Content): 'Anthropic may not train models on Customer Content from Services.'",
+          "retrieved": "2026-08-21"
+        }
+      }
+    },
+    "google_gemini": {
+      "training_default": "no",
+      "retention": "Paid Services: prompts and responses logged for a limited period solely for detecting/preventing Prohibited Use Policy violations; Grounding with Google Search/Maps stores prompts and outputs for 30 days. Unpaid Services: content may be used to improve Google products (do not submit confidential data).",
+      "subprocessors": {
+        "url": "https://cloud.google.com/terms/subprocessors",
+        "locator": "Google Cloud Platform Subprocessors page (last modified August 19, 2026 at review time)",
+        "retrieved": "2026-08-21"
+      },
+      "enterprise_tier": "The paid/unpaid split is the effective tier boundary: unpaid Gemini API quota and free-tier AI Studio use submissions to improve Google products; EEA/Switzerland/UK users get the paid (no-training) rules even on unpaid Services.",
+      "reviewed": "2026-08-21",
+      "citations": {
+        "training_default": {
+          "url": "https://ai.google.dev/gemini-api/terms",
+          "locator": "Paid Services - How Google Uses Your Data: 'Google doesn't use your prompts ... or responses to improve our products' (Unpaid Services section states the opposite for free usage)",
+          "retrieved": "2026-08-21"
+        },
+        "retention": {
+          "url": "https://ai.google.dev/gemini-api/terms",
+          "locator": "Paid Services: 'Google logs prompts and responses for a limited period of time, solely for detecting and preventing violations of the Prohibited Use Policy'; Grounding sections: 'store prompts ... for thirty (30) days'",
+          "retrieved": "2026-08-21"
+        },
+        "enterprise_tier": {
+          "url": "https://ai.google.dev/gemini-api/terms",
+          "locator": "Unpaid Services - How Google Uses Your Data; 'If you're in the European Economic Area, Switzerland, or the United Kingdom, the terms under Paid Services apply to all Services'",
+          "retrieved": "2026-08-21"
+        }
+      }
+    },
+    "azure_openai": {
+      "training_default": "no",
+      "retention": "Models are stateless: no prompts or completions are stored in the model. Stateful features (Responses API, Assistants Threads, Stored completions, Files/vector stores) persist data in the resource's Azure geography until deleted. Abuse monitoring stores prompt/completion samples only when flagged, in logically separated per-resource stores; modified abuse monitoring turns this off for approved customers.",
+      "subprocessors": {
+        "url": "https://aka.ms/DPA",
+        "locator": "Microsoft Products and Services Data Protection Addendum, linked from the data-privacy article intro",
+        "retrieved": "2026-08-21"
+      },
+      "enterprise_tier": "Modified abuse monitoring requires application and approval; customers can verify logging is off via the ContentLogging=false capability attribute in the Azure portal/CLI.",
+      "reviewed": "2026-08-21",
+      "citations": {
+        "training_default": {
+          "url": "https://learn.microsoft.com/en-us/legal/cognitive-services/openai/data-privacy",
+          "locator": "'prompts and completions are NOT used to train any generative AI foundation models without your permission or instruction'; 'The models are stateless: no prompts or completions are stored in the model'",
+          "retrieved": "2026-08-21"
+        },
+        "retention": {
+          "url": "https://learn.microsoft.com/en-us/legal/cognitive-services/openai/data-privacy",
+          "locator": "Sections 'Generating completions...' (stateless models), 'Data storage for Models sold by Azure features', and 'Preventing abuse' (flagged-sample storage, logical separation, modified abuse monitoring)",
+          "retrieved": "2026-08-21"
+        },
+        "enterprise_tier": {
+          "url": "https://learn.microsoft.com/en-us/legal/cognitive-services/openai/data-privacy",
+          "locator": "'How can a customer verify if data storage for abuse monitoring is off?' (ContentLogging=false); 'managed customers may apply to modify abuse monitoring'",
+          "retrieved": "2026-08-21"
+        }
+      }
+    },
+    "aws_bedrock": {
+      "training_default": null,
+      "retention": "Zero data retention by default (zero operator access + ZDR security model): Bedrock does not store model inputs or outputs. Exceptions retain inputs/outputs up to 30 days for automated abuse detection (e.g. classifier-flagged traffic of certain hosted OpenAI GPT-5.x models; Claude Fable 5 retains up to 30 days). Setting data_retention_mode to 'none' enforces zero retention account/project-wide.",
+      "subprocessors": null,
+      "enterprise_tier": "Some models (Claude Mythos 5, Claude Fable 5) require opting into provider_data_share, which retains and shares inference data with Anthropic for up to 30 days; full ZDR access for models requiring retention is evaluated per-account/per-model via the AWS account team.",
+      "reviewed": "2026-08-21",
+      "citations": {
+        "retention": {
+          "url": "https://docs.aws.amazon.com/bedrock/latest/userguide/data-retention.html",
+          "locator": "Data retention modes table ('none': 'No request or response data is written to durable storage'); 'What data is retained and for how long' (30-day abuse-detection retention)",
+          "retrieved": "2026-08-21"
+        },
+        "enterprise_tier": {
+          "url": "https://docs.aws.amazon.com/bedrock/latest/userguide/abuse-detection.html",
+          "locator": "'For Anthropic Claude Fable 5, inputs and outputs will be retained for up to 30 days ... you must opt in to sharing retained traffic with Anthropic'; ZDR access section of the data-retention page",
+          "retrieved": "2026-08-21"
+        }
+      }
+    }
+  }
+}

--- a/borderlint/kb.py
+++ b/borderlint/kb.py
@@ -2,9 +2,23 @@
 
 from __future__ import annotations
 
+import datetime as dt
 import json
 import re
 from importlib.resources import files
+
+_ISO_DATE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _iso_date(s: str) -> bool:
+    """True for a valid ISO-8601 YYYY-MM-DD date string."""
+    if not _ISO_DATE.match(s or ""):
+        return False
+    try:
+        dt.date.fromisoformat(s)
+        return True
+    except ValueError:
+        return False
 
 # Region-coded endpoints (the host carries the region) → ccTLD jurisdiction.
 _AWS_RE = re.compile(r"\b([a-z]{2}(?:-gov)?-[a-z]+-\d)\b")
@@ -179,6 +193,38 @@ def _load_provenance_map() -> dict:
     return json.loads(files("borderlint").joinpath("data/provenance.json").read_text("utf-8"))
 
 
+# --- Data-practices dimension -------------------------------------------------
+# Per-provider data-practice facts (training default, retention, subprocessors, enterprise
+# delta), hand-curated with per-fact citations. Strictly advisory: read-only for renderers,
+# never consulted by detection or policy evaluation.
+_TRAINING_DEFAULTS = frozenset({"yes", "no", "opt-out"})
+
+
+def _valid_training_default(token) -> bool:
+    return token is None or token in _TRAINING_DEFAULTS
+
+
+def _validate_data_practices(entries: dict) -> dict:
+    """Raise loudly on an invalid training default, missing review date, or incomplete citation."""
+    for pid, entry in entries.items():
+        if not _valid_training_default(entry.get("training_default")):
+            raise ValueError(
+                f"invalid training_default '{entry.get('training_default')}' for provider '{pid}' "
+                "(use one of yes, no, opt-out, or null when undocumented)")
+        if not _iso_date(entry.get("reviewed", "")):
+            raise ValueError(f"data-practices entry '{pid}' has no ISO-8601 'reviewed' date")
+        for fact, cite in entry.get("citations", {}).items():
+            if not all(cite.get(k) for k in ("url", "locator", "retrieved")):
+                raise ValueError(f"citation for '{fact}' on '{pid}' needs url, locator, retrieved")
+    return entries
+
+
+def load_data_practices() -> dict:
+    """Bundled provider id → data-practice entry (advisory; each fact carries its citation)."""
+    doc = json.loads(files("borderlint").joinpath("data/data_practices.json").read_text("utf-8"))
+    return _validate_data_practices(dict(doc.get("entries", {})))
+
+
 def _endpoints_provider(endpoints: dict) -> dict:
     for host, juris in endpoints.items():
         if not _valid_jurisdiction(juris):
@@ -241,6 +287,7 @@ def load_kb(path: str | None = None) -> "KB":
     kb.provenance_defaults = dict(prov_doc.get("provider_defaults", {}))
     kb.provenance_passthrough = [o.lower() for o in prov_doc.get("passthrough_orgs", [])]
     kb.provenance_updated = prov_doc.get("updated")
+    kb.data_practices = load_data_practices()
     kb.set_provenance_patterns(prov_patterns, user_prov_patterns)
     return kb
 

--- a/borderlint/report.py
+++ b/borderlint/report.py
@@ -105,6 +105,14 @@ def _arrangements(findings, policy) -> list[str]:
     return [_ref(aid) for aid in _arrangement_ids(findings, policy)]
 
 
+def _cite_suffix(cite: dict) -> str:
+    """Markdown citation suffix for a data-practices fact: source link + retrieval date."""
+    if not cite or not cite.get("url"):
+        return ""
+    loc = f"; {cite['locator']}" if cite.get("locator") else ""
+    return f" — [source]({cite['url']}{loc}, retrieved {cite.get('retrieved', 'unavailable')})"
+
+
 def _regimes(findings, policy) -> list[str]:
     """Regime tag(s) implicated by a flagged flow — {PDPO, PIPL, Macao PDPA}, informational."""
     policy = policy or {}
@@ -623,6 +631,39 @@ def evidence(findings, kb, policy=None, envelope=None) -> str:
     else:
         out.append("No active waivers.")
     out.append("")
+
+    # Data-practices register (advisory): curated facts with citations; uncurated providers
+    # stay visible as "not curated". Never affects verdicts or summary counts.
+    seen_providers = list(dict.fromkeys(f.detection.provider_id for f in findings))
+    if seen_providers:
+        dp = getattr(kb, "data_practices", {}) or {}
+        out += ["## Data practices (advisory)", "",
+                "_Statements about providers' documented practices as of each fact's retrieval"
+                " date — not legal advice._", ""]
+        for pid in seen_providers:
+            entry = dp.get(pid)
+            if not entry:
+                out.append(f"- **{kb.name(pid)}** — not curated (no verified data-practice facts).")
+                continue
+            out.append(f"- **{kb.name(pid)}** (reviewed {entry.get('reviewed', 'unavailable')})")
+            td = entry.get("training_default")
+            if td is not None:
+                c = entry.get("citations", {}).get("training_default", {})
+                out.append(f"  - Trains on customer API data by default: **{td}**"
+                           + _cite_suffix(c))
+            ret = entry.get("retention")
+            if ret is not None:
+                c = entry.get("citations", {}).get("retention", {})
+                out.append(f"  - Retention: {ret}" + _cite_suffix(c))
+            sub = entry.get("subprocessors")
+            if sub:
+                out.append(f"  - Subprocessor list: <{sub['url']}>"
+                           f" (retrieved {sub['retrieved']}; {sub['locator']})")
+            ent = entry.get("enterprise_tier")
+            if ent is not None:
+                c = entry.get("citations", {}).get("enterprise_tier", {})
+                out.append(f"  - Enterprise tier: {ent}" + _cite_suffix(c))
+        out.append("")
 
     if has_policy:
         counts = {}

--- a/borderlint/report.py
+++ b/borderlint/report.py
@@ -106,11 +106,16 @@ def _arrangements(findings, policy) -> list[str]:
 
 
 def _cite_suffix(cite: dict) -> str:
-    """Markdown citation suffix for a data-practices fact: source link + retrieval date."""
+    """Markdown citation suffix for a data-practices fact: source link + retrieval date.
+
+    Only the URL belongs inside the link target; the locator note stays outside so the
+    href remains a valid URL.
+    """
     if not cite or not cite.get("url"):
         return ""
     loc = f"; {cite['locator']}" if cite.get("locator") else ""
-    return f" — [source]({cite['url']}{loc}, retrieved {cite.get('retrieved', 'unavailable')})"
+    return (f" — [source]({cite['url']}){loc},"
+            f" retrieved {cite.get('retrieved', 'unavailable')}")
 
 
 def _regimes(findings, policy) -> list[str]:

--- a/openspec/changes/provider-data-practice-facts/.openspec.yaml
+++ b/openspec/changes/provider-data-practice-facts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-21

--- a/openspec/changes/provider-data-practice-facts/design.md
+++ b/openspec/changes/provider-data-practice-facts/design.md
@@ -1,0 +1,86 @@
+# Design: provider-data-practice-facts
+
+## Context
+
+borderlint bundles several hand-curated knowledge bases (`providers.json`, `sovereignty.json`,
+`provenance.json`, `regimes.json`, …), each loaded by a small stdlib-JSON function in
+`borderlint/kb.py` and each carrying a top-level last-reviewed date consumed by
+`scripts/kb_drift.py`. The KB website (`scripts/kb_site.py`) renders provider pages from
+these files, and the evidence pack (`borderlint/report.py`) renders per-flow governance
+facts. Data-practice facts (training default, retention, subprocessors, enterprise delta)
+are a new dimension over the same provider ids, with a different review cadence and a
+citation-per-fact shape none of the existing KBs have.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A bundled, citable, review-dated data-practice KB keyed by existing provider ids.
+- Reviewer-facing surfacing: evidence pack register + KB website provider pages.
+- Staleness and curation-gap coverage in the scheduled drift check.
+- Strictly advisory: zero influence on detection, verdicts, or exit codes.
+
+**Non-Goals:**
+
+- No auto-scraping or auto-fill of ToS content; no upstream feed ingestion for facts.
+- No new CLI flags or JSON output fields (consumers can be added later without breakage).
+- No legal analysis or regime-specific advice beyond the existing annex behaviour.
+- No restructuring of `providers.json`.
+
+## Decisions
+
+### D1: Separate `data_practices.json`, not new fields on `providers.json`
+Facts have their own cadence, schema (citations), and curation workflow. Mixing them into
+provider entries would force residency re-reviews whenever a ToS fact changes and would
+bloat the core resolution path.
+*Alternative rejected:* extend `providers.json` entries — couples unrelated review cycles
+and complicates the hot loader.
+
+### D2: Per-fact citation objects `{url, locator, retrieved}`
+The four facts typically live on different pages/sections of a provider's documentation;
+a single per-entry source would be wrong as soon as one fact updates.
+*Alternative rejected:* one source link per entry — loses precision reviewers need to
+verify claims.
+
+### D3: Retention stored as free text, not a structured duration
+Real windows are conditional ("30 days unless legally required", "zero-retention for
+enterprise"). Structured day-counts would encode false precision.
+*Alternative rejected:* numeric retention days — cannot express conditions; would invite
+wrong comparisons.
+
+### D4: Standalone loader function following the existing pattern
+A `load_data_practices()` function in `kb.py` mirroring `load_sovereignty()`/
+`load_provenance()`: stdlib JSON, offline, returns a plain dict keyed by provider id.
+Missing file is a packaging error (fail loud), consistent with other KBs.
+
+### D5: Drift integration reuses the suppression list and report-item upsert
+Two new sections in `scripts/kb_drift.py` — stale data-practices entries and providers
+lacking coverage — flow through the existing open-item update logic (no duplicates across
+runs) and honour `kb_drift_aliases.json` suppressions. Gap records carry no fact values,
+per spec.
+
+### D6: Seed curation covers flagship providers only
+Initial entries for the highest-traffic providers (e.g. OpenAI, Anthropic, Google, Azure
+OpenAI, AWS Bedrock); everything else surfaces honestly as "not curated". Curation depth
+grows via PRs, matching the project's contribution model.
+
+## Risks / Trade-offs
+
+- [ToS facts silently go stale] → retrieval dates rendered everywhere + staleness section
+  in the drift check on the standard review interval.
+- [Readers mistake facts for legal advice] → mandatory disclaimer on every rendering
+  surface, enforced by spec scenarios and tests.
+- [Provider-id drift between the two KBs] → drift check reports mismatches; loader tests
+  assert every data-practices key exists in `providers.json`.
+- [Package size growth] → a few KB of JSON; negligible against existing bundled KBs.
+
+## Migration Plan
+
+Purely additive: new data file, new loader, new render sections. Rollback is removing the
+file and the render call sites; scanners never depend on the KB, so no behavioural rollback
+is needed. No data migration.
+
+## Open Questions
+
+- Exact seed provider list and per-provider citations (resolved during implementation by
+  reading current public documentation; each fact needs URL + locator + retrieval date).

--- a/openspec/changes/provider-data-practice-facts/proposal.md
+++ b/openspec/changes/provider-data-practice-facts/proposal.md
@@ -1,0 +1,58 @@
+# Proposal: provider-data-practice-facts
+
+## Why
+
+Privacy reviewers evaluating AI providers ask the same four questions first — does the
+provider train on my API data by default, what is the retention window, where is the
+subprocessor list, and does an enterprise tier change the answer — and today they dig each
+answer out of scattered ToS pages. borderlint already earns trust by hand-curating
+residency and sovereignty facts; these data-practice facts are the adjacent set with the
+same curation-is-the-value property. Surfacing them in the evidence pack means a reviewer
+gets the answers next to the flow inventory they are already filing.
+
+## What Changes
+
+- Add a bundled, hand-curated knowledge base of per-provider data-practice facts covering
+  the four canonical questions, each fact carrying a source citation (URL + locator note)
+  and a retrieval date, with each entry carrying its own last-reviewed date.
+- Expose the facts through the KB loader (offline, stdlib JSON, no schema break to
+  existing entries).
+- Render a data-practices section on each provider page of the KB website: facts, citations
+  as hyperlinks, as-of dates, and an advisory disclaimer. Providers without curated facts
+  state that explicitly.
+- Extend the evidence pack with a per-provider data-practices register (citations and
+  as-of dates included; uncurated providers rendered as explicitly not curated).
+- Cover the new knowledge base in the scheduled freshness/staleness check so facts are
+  re-reviewed on the standard interval.
+- Facts are advisory statements about documented practices — never legal advice and never
+  auto-filled from upstream feeds.
+
+## Non-goals
+
+- No auto-scraping or auto-fill of ToS content; facts enter only via human-curated PRs.
+- No new CLI flags or JSON output fields; surfacing is limited to the evidence format and
+  the KB website.
+- No legal analysis beyond advisory statements about documented practices.
+- No restructuring of the existing `providers.json` knowledge base.
+
+## Capabilities
+
+### New Capabilities
+- `provider-data-practices`: bundled per-provider data-practice facts (training default,
+  retention, subprocessors, enterprise-tier delta) with citations, review dates, human
+  curation, and explicit absence handling.
+
+### Modified Capabilities
+- `kb-website`: provider pages gain a data-practices section with citations and disclaimer.
+- `cli-and-reporting`: the evidence pack gains a data-practices register for providers in
+  the flow inventory.
+- `kb-freshness`: the staleness check explicitly covers the data-practices knowledge base.
+
+## Impact
+
+- New bundled data file (`borderlint/data/data_practices.json`) — shipped package grows,
+  no new runtime dependencies.
+- `borderlint/kb.py` loader; `borderlint/report.py` evidence renderer; `scripts/kb_site.py`
+  generator; `scripts/kb_drift.py` staleness inputs; `tests/test_borderlint.py`.
+- No CLI surface change: the facts appear only in the `evidence` format and the KB website.
+- No detection or policy-evaluation behaviour changes.

--- a/openspec/changes/provider-data-practice-facts/specs/cli-and-reporting/spec.md
+++ b/openspec/changes/provider-data-practice-facts/specs/cli-and-reporting/spec.md
@@ -1,0 +1,23 @@
+# cli-and-reporting Delta
+
+## ADDED Requirements
+
+### Requirement: Evidence pack data-practices register
+The evidence pack SHALL include a data-practices register listing, for every provider in
+the flow inventory that has a curated entry, its training default, retention window,
+subprocessor link, and enterprise-tier note, each with source citation and retrieval date.
+Providers in the inventory without a curated entry SHALL appear in the register marked as
+not curated. The register SHALL carry the advisory disclaimer and SHALL NOT affect verdicts
+or summary counts.
+
+#### Scenario: Curated providers are registered with citations
+- **WHEN** the evidence pack renders a flow whose provider has a curated data-practices entry
+- **THEN** the register lists that provider's facts with citations and retrieval dates
+
+#### Scenario: Uncurated providers stay visible
+- **WHEN** the evidence pack renders a flow whose provider has no curated entry
+- **THEN** the register marks that provider as not curated rather than omitting it
+
+#### Scenario: The register leaves verdicts untouched
+- **WHEN** the same tree and policy are scanned with and without the data-practices knowledge base present
+- **THEN** both runs produce identical verdicts, summary counts, and exit codes

--- a/openspec/changes/provider-data-practice-facts/specs/kb-freshness/spec.md
+++ b/openspec/changes/provider-data-practice-facts/specs/kb-freshness/spec.md
@@ -1,0 +1,18 @@
+# kb-freshness Delta
+
+## ADDED Requirements
+
+### Requirement: Data-practices staleness coverage
+The scheduled coverage check SHALL include the data-practice knowledge base in its
+staleness review: entries whose last-reviewed date exceeds the review interval SHALL be
+reported for re-review, and providers present in the bundled provider knowledge base but
+absent from the data-practice knowledge base SHALL be reported as curation gaps unless
+suppressed by the curated suppression list. Gap records SHALL carry no fact values.
+
+#### Scenario: A stale data-practices entry is reported
+- **WHEN** the scheduled check runs and a data-practices entry's last-reviewed date exceeds the review interval
+- **THEN** that entry is reported for re-review
+
+#### Scenario: A provider without data-practices coverage is a gap
+- **WHEN** the scheduled check runs and a bundled provider has no data-practices entry and is not suppressed
+- **THEN** the provider is reported as a data-practices curation gap carrying no fact values

--- a/openspec/changes/provider-data-practice-facts/specs/kb-website/spec.md
+++ b/openspec/changes/provider-data-practice-facts/specs/kb-website/spec.md
@@ -1,0 +1,19 @@
+# kb-website Delta
+
+## ADDED Requirements
+
+### Requirement: Provider page data-practices section
+Each provider page SHALL render a data-practices section when the provider has a curated
+entry, stating the training default, retention window, subprocessor link, and
+enterprise-tier note, each fact with its source citation rendered as a hyperlink and its
+retrieval date. Pages for providers without a curated entry SHALL state that data
+practices are not curated for that provider. Every data-practices rendering SHALL include
+the advisory disclaimer.
+
+#### Scenario: A curated provider page renders facts with citations
+- **WHEN** the page for a provider with a curated data-practices entry is generated
+- **THEN** it states the four facts, renders each citation as a hyperlink with its retrieval date, and includes the advisory disclaimer
+
+#### Scenario: An uncurated provider page says so
+- **WHEN** the page for a provider without a curated entry is generated
+- **THEN** the data-practices section states that data practices are not curated for the provider

--- a/openspec/changes/provider-data-practice-facts/specs/provider-data-practices/spec.md
+++ b/openspec/changes/provider-data-practice-facts/specs/provider-data-practices/spec.md
@@ -1,0 +1,56 @@
+# provider-data-practices Delta
+
+## ADDED Requirements
+
+### Requirement: Bundled curated data-practice facts
+The system SHALL bundle a hand-curated knowledge base of per-provider data-practice facts,
+where each provider entry records: whether the provider trains on customer API data by
+default (`yes`, `no`, or `opt-out`), the retention window for API inputs and outputs when
+publicly documented, a link to the subprocessor list when one exists, and whether an
+enterprise tier changes any of these answers. Every entry SHALL carry a top-level
+last-reviewed date in ISO-8601 (`YYYY-MM-DD`) form, consistent with the other bundled
+knowledge bases.
+
+#### Scenario: A fully curated provider entry
+- **WHEN** the data-practice knowledge base is loaded for a provider with all four facts curated
+- **THEN** the entry exposes the training default, the retention window, the subprocessor link, and the enterprise-tier note alongside its last-reviewed date
+
+#### Scenario: A partially curated provider entry
+- **WHEN** the data-practice knowledge base is loaded for a provider where only some facts are publicly documented
+- **THEN** the undocumented facts are recorded as explicitly unknown rather than omitted or guessed
+
+### Requirement: Source citation per fact
+Each data-practice fact SHALL carry a source citation consisting of a URL and a locator
+note identifying where in the source the statement is made, together with the date the
+fact was retrieved from that source.
+
+#### Scenario: A fact renders with its citation
+- **WHEN** a data-practice fact is surfaced anywhere by borderlint
+- **THEN** it is presented with its source URL, locator note, and retrieval date
+
+### Requirement: Human curation only
+The data-practice knowledge base SHALL be populated exclusively by human curation via pull
+request; the system SHALL NOT auto-fill any fact from upstream feeds, and the scheduled
+coverage check SHALL NOT propose values for missing facts.
+
+#### Scenario: Drift output proposes no facts
+- **WHEN** the scheduled check reports a provider missing from the data-practice knowledge base
+- **THEN** the gap record carries no training default, retention window, or subprocessor link
+
+### Requirement: Explicit absence handling
+borderlint SHALL state that data practices are not curated for a provider detected in a
+scan but absent from the data-practice knowledge base, rather than rendering empty values,
+and SHALL NOT fail the scan on that absence.
+
+#### Scenario: An uncurated provider in a scan
+- **WHEN** a scan detects a provider absent from the data-practice knowledge base
+- **THEN** the scan exits normally and surfaces the provider as not curated for data practices
+
+### Requirement: Advisory framing
+All rendered data-practice facts SHALL be framed as advisory statements about providers'
+documented practices as of their retrieval dates, with a visible disclaimer that they are
+not legal advice; facts SHALL never influence verdicts, policy evaluation, or exit codes.
+
+#### Scenario: Facts never change a verdict
+- **WHEN** a scan produces findings for a provider whose curated facts are present
+- **THEN** the verdicts and exit code are identical to a run without the data-practice knowledge base

--- a/openspec/changes/provider-data-practice-facts/tasks.md
+++ b/openspec/changes/provider-data-practice-facts/tasks.md
@@ -1,0 +1,37 @@
+# Tasks: provider-data-practice-facts
+
+## 1. Knowledge base data and loader
+
+- [ ] 1.1 Create `borderlint/data/data_practices.json` with the entry schema from design D1–D3: per-provider `training_default` (`yes`|`no`|`opt-out`), `retention`, `subprocessors` link, `enterprise_tier` note, per-fact citation objects `{url, locator, retrieved}`, top-level ISO-8601 last-reviewed date (D1, D2, D3)
+- [ ] 1.2 Add `load_data_practices()` to `borderlint/kb.py` following the existing stdlib-JSON loader pattern; fail loud on missing file (D4)
+- [ ] 1.3 Add tests: schema shape, every key exists in `providers.json`, last-reviewed date parses as ISO-8601, citations carry url/locator/retrieved
+
+## 2. Advisory guarantees
+
+- [ ] 2.1 Add test proving verdicts, summary counts, and exit codes are identical with and without the data-practices KB present for the same tree and policy
+- [ ] 2.2 Add test that an uncurated detected provider does not fail a scan and is surfaced as not curated
+
+## 3. Evidence pack register
+
+- [ ] 3.1 Extend the evidence renderer in `borderlint/report.py` with a data-practices register: curated providers with facts + citations + retrieval dates, uncurated providers marked not curated, advisory disclaimer on the register
+- [ ] 3.2 Add tests covering the three register scenarios (curated listed with citations, uncurated visible, verdicts untouched)
+
+## 4. KB website section
+
+- [ ] 4.1 Extend `scripts/kb_site.py` provider pages with the data-practices section: facts, hyperlinked citations with retrieval dates, disclaimer; "not curated" statement for providers without entries
+- [ ] 4.2 Add generator tests for both page variants (curated / uncurated)
+
+## 5. Freshness coverage
+
+- [ ] 5.1 Extend `scripts/kb_drift.py` with stale-entry and missing-provider sections reusing the suppression list and open-item upsert; gap records carry no fact values (D5)
+- [ ] 5.2 Add drift tests: stale entry reported, unsuppressed gap reported with no fact values, suppressed provider excluded
+
+## 6. Seed curation and docs
+
+- [ ] 6.1 Curate seed entries for flagship providers (OpenAI, Anthropic, Google, Azure OpenAI, AWS Bedrock), each fact sourced with URL + locator + retrieval date read from current public documentation (D6)
+- [ ] 6.2 Document the new KB in CONTRIBUTING.md (schema, human-curation rule, review cadence)
+
+## 7. Validation
+
+- [ ] 7.1 Run full pytest suite and fix regressions
+- [ ] 7.2 Run `openspec validate provider-data-practice-facts --strict`

--- a/openspec/changes/provider-data-practice-facts/tasks.md
+++ b/openspec/changes/provider-data-practice-facts/tasks.md
@@ -2,36 +2,36 @@
 
 ## 1. Knowledge base data and loader
 
-- [ ] 1.1 Create `borderlint/data/data_practices.json` with the entry schema from design D1–D3: per-provider `training_default` (`yes`|`no`|`opt-out`), `retention`, `subprocessors` link, `enterprise_tier` note, per-fact citation objects `{url, locator, retrieved}`, top-level ISO-8601 last-reviewed date (D1, D2, D3)
-- [ ] 1.2 Add `load_data_practices()` to `borderlint/kb.py` following the existing stdlib-JSON loader pattern; fail loud on missing file (D4)
-- [ ] 1.3 Add tests: schema shape, every key exists in `providers.json`, last-reviewed date parses as ISO-8601, citations carry url/locator/retrieved
+- [x] 1.1 Create `borderlint/data/data_practices.json` with the entry schema from design D1–D3: per-provider `training_default` (`yes`|`no`|`opt-out`), `retention`, `subprocessors` link, `enterprise_tier` note, per-fact citation objects `{url, locator, retrieved}`, top-level ISO-8601 last-reviewed date (D1, D2, D3)
+- [x] 1.2 Add `load_data_practices()` to `borderlint/kb.py` following the existing stdlib-JSON loader pattern; fail loud on missing file (D4)
+- [x] 1.3 Add tests: schema shape, every key exists in `providers.json`, last-reviewed date parses as ISO-8601, citations carry url/locator/retrieved
 
 ## 2. Advisory guarantees
 
-- [ ] 2.1 Add test proving verdicts, summary counts, and exit codes are identical with and without the data-practices KB present for the same tree and policy
-- [ ] 2.2 Add test that an uncurated detected provider does not fail a scan and is surfaced as not curated
+- [x] 2.1 Add test proving verdicts, summary counts, and exit codes are identical with and without the data-practices KB present for the same tree and policy
+- [x] 2.2 Add test that an uncurated detected provider does not fail a scan and is surfaced as not curated
 
 ## 3. Evidence pack register
 
-- [ ] 3.1 Extend the evidence renderer in `borderlint/report.py` with a data-practices register: curated providers with facts + citations + retrieval dates, uncurated providers marked not curated, advisory disclaimer on the register
-- [ ] 3.2 Add tests covering the three register scenarios (curated listed with citations, uncurated visible, verdicts untouched)
+- [x] 3.1 Extend the evidence renderer in `borderlint/report.py` with a data-practices register: curated providers with facts + citations + retrieval dates, uncurated providers marked not curated, advisory disclaimer on the register
+- [x] 3.2 Add tests covering the three register scenarios (curated listed with citations, uncurated visible, verdicts untouched)
 
 ## 4. KB website section
 
-- [ ] 4.1 Extend `scripts/kb_site.py` provider pages with the data-practices section: facts, hyperlinked citations with retrieval dates, disclaimer; "not curated" statement for providers without entries
-- [ ] 4.2 Add generator tests for both page variants (curated / uncurated)
+- [x] 4.1 Extend `scripts/kb_site.py` provider pages with the data-practices section: facts, hyperlinked citations with retrieval dates, disclaimer; "not curated" statement for providers without entries
+- [x] 4.2 Add generator tests for both page variants (curated / uncurated)
 
 ## 5. Freshness coverage
 
-- [ ] 5.1 Extend `scripts/kb_drift.py` with stale-entry and missing-provider sections reusing the suppression list and open-item upsert; gap records carry no fact values (D5)
-- [ ] 5.2 Add drift tests: stale entry reported, unsuppressed gap reported with no fact values, suppressed provider excluded
+- [x] 5.1 Extend `scripts/kb_drift.py` with stale-entry and missing-provider sections reusing the suppression list and open-item upsert; gap records carry no fact values (D5)
+- [x] 5.2 Add drift tests: stale entry reported, unsuppressed gap reported with no fact values, suppressed provider excluded
 
 ## 6. Seed curation and docs
 
-- [ ] 6.1 Curate seed entries for flagship providers (OpenAI, Anthropic, Google, Azure OpenAI, AWS Bedrock), each fact sourced with URL + locator + retrieval date read from current public documentation (D6)
-- [ ] 6.2 Document the new KB in CONTRIBUTING.md (schema, human-curation rule, review cadence)
+- [x] 6.1 Curate seed entries for flagship providers (OpenAI, Anthropic, Google, Azure OpenAI, AWS Bedrock), each fact sourced with URL + locator + retrieval date read from current public documentation (D6)
+- [x] 6.2 Document the new KB in CONTRIBUTING.md (schema, human-curation rule, review cadence)
 
 ## 7. Validation
 
-- [ ] 7.1 Run full pytest suite and fix regressions
-- [ ] 7.2 Run `openspec validate provider-data-practice-facts --strict`
+- [x] 7.1 Run full pytest suite and fix regressions
+- [x] 7.2 Run `openspec validate provider-data-practice-facts --strict`

--- a/scripts/kb_drift.py
+++ b/scripts/kb_drift.py
@@ -72,6 +72,11 @@ def validate_suppression(supp: dict, provider_ids: set[str]) -> dict:
             raise ValueError(f"drift sdk_exempt '{pid}' is not a bundled provider id")
         if not (reason or "").strip():
             raise ValueError(f"drift sdk_exempt '{pid}' has no reason")
+    for pid, reason in supp.get("data_practices_exempt", {}).items():
+        if pid not in provider_ids:
+            raise ValueError(f"drift data_practices_exempt '{pid}' is not a bundled provider id")
+        if not (reason or "").strip():
+            raise ValueError(f"drift data_practices_exempt '{pid}' has no reason")
     return supp
 
 
@@ -185,12 +190,41 @@ def stale_kbs(kb_dates: dict, today: dt.date,
     return out
 
 
+def data_practices_stale(dp_doc: dict, today: dt.date,
+                         interval_days: int = STALE_DAYS) -> list[tuple[str, str, int]]:
+    """(provider id, reviewed, age_days) for data-practices entries older than the interval."""
+    out = []
+    for pid, entry in sorted(dp_doc.get("entries", {}).items()):
+        reviewed = entry.get("reviewed")
+        if not reviewed:
+            out.append((pid, "missing date", -1))
+            continue
+        age = (today - dt.date.fromisoformat(reviewed)).days
+        if age > interval_days:
+            out.append((pid, reviewed, age))
+    return out
+
+
+def data_practices_gaps(provider_ids: list[str], dp_doc: dict,
+                        suppression: dict | None = None) -> list[str]:
+    """Bundled provider ids with no data-practices entry — ids only, sorted.
+
+    Suppressed via the curated suppression list's `data_practices_exempt` map (id → reason).
+    Gap records carry NO fact values: facts are assigned by hand via pull request.
+    """
+    exempt = set(suppression.get("data_practices_exempt", {})) if suppression else set()
+    covered = set(dp_doc.get("entries", {}))
+    return sorted(pid for pid in set(provider_ids) if pid not in covered and pid not in exempt)
+
+
 def render_report(today: dt.date, providers_gap: list[str],
                   families: list[tuple[str, int, str]],
                   sov_gaps: list[tuple[str, str | None]], stale: list[tuple[str, str, int]],
                   family_cap: int = FAMILY_CAP,
                   residue: list[tuple[str, int]] | None = None,
-                  sdk_gaps: list[tuple[str, list[str]]] | None = None) -> str:
+                  sdk_gaps: list[tuple[str, list[str]]] | None = None,
+                  dp_stale: list[tuple[str, str, int]] | None = None,
+                  dp_gaps: list[str] | None = None) -> str:
     """Markdown issue body: empty sections omitted; empty report is the empty string.
 
     The summary head carries the reference date so week-over-week identical findings
@@ -199,11 +233,15 @@ def render_report(today: dt.date, providers_gap: list[str],
     parts = []
     residue_total = sum(n for _, n in residue) if residue else 0
     sdk = sdk_gaps or []
-    if providers_gap or families or sov_gaps or stale or residue_total or sdk:
-        n_act = len(providers_gap) + len(families) + len(sov_gaps) + len(stale) + len(sdk)
+    dps = dp_stale or []
+    dpg = dp_gaps or []
+    if providers_gap or families or sov_gaps or stale or residue_total or sdk or dps or dpg:
+        n_act = (len(providers_gap) + len(families) + len(sov_gaps) + len(stale) + len(sdk)
+                 + len(dps) + len(dpg))
         head = (f"**Actionable:** {len(providers_gap)} providers \u00b7 {len(families)} model "
                 f"families \u00b7 {len(sov_gaps)} sovereignty gaps \u00b7 {len(stale)} stale KBs "
-                f"\u00b7 {len(sdk)} SDK gaps "
+                f"\u00b7 {len(sdk)} SDK gaps \u00b7 {len(dps)} stale data-practice entries "
+                f"\u00b7 {len(dpg)} data-practice gaps "
                 f"\u2014 **acknowledged residue:** {residue_total} ids \u00b7 checked {today}")
         if n_act == 0:
             head = (f"**Nothing actionable.** Acknowledged residue: {residue_total} ids "
@@ -246,6 +284,21 @@ def render_report(today: dt.date, providers_gap: list[str],
             "reasoned exemption in `scripts/kb_drift_aliases.json` (`sdk_exempt`).\n\n"
             + "\n".join(f"- `{pid}` — missing {', '.join(f'`{k}`' for k in missing)}"
                         for pid, missing in sdk))
+    if dps:
+        parts.append(
+            f"### Stale data-practice entries\n\n"
+            f"Reviewed more than {STALE_DAYS} days ago — re-verify each cited source and bump "
+            f"`reviewed`. Facts are advisory statements, not legal advice.\n\n"
+            + "\n".join(f"- `{pid}` — reviewed {date}, {age} days ago"
+                        for pid, date, age in dps))
+    if dpg:
+        parts.append(
+            "### Data-practice gaps\n\n"
+            "Bundled providers with no curated data-practice entry. Curate **by hand** via pull "
+            "request (each fact needs a source URL + locator + retrieval date) — or record a "
+            "reasoned exemption in `scripts/kb_drift_aliases.json` (`data_practices_exempt`). "
+            "Never auto-fill.\n\n"
+            + "\n".join(f"- `{pid}`" for pid in dpg))
     if residue_total:
         rows = "\n".join(f"- {reason} — {n} id{'s' if n > 1 else ''}"
                          for reason, n in residue)
@@ -278,9 +331,14 @@ def main() -> int:
     today = dt.date.today()
     stale = stale_kbs({k: v for k, v in kb_dates.items() if v}, today)
     sdk_gaps = sdk_coverage_gaps(providers_doc["providers"], suppression)
+    with open(DATA_DIR / "data_practices.json", encoding="utf-8") as fh:
+        dp_doc = json.load(fh)
+    dp_stale = data_practices_stale(dp_doc, today)
+    dp_gaps = data_practices_gaps([p["id"] for p in providers_doc["providers"]], dp_doc,
+                                  suppression)
 
     report = render_report(today, providers_gap, families, sov_gaps, stale, residue=residue,
-                           sdk_gaps=sdk_gaps)
+                           sdk_gaps=sdk_gaps, dp_stale=dp_stale, dp_gaps=dp_gaps)
     if report:
         print(report)
     return 0

--- a/scripts/kb_site.py
+++ b/scripts/kb_site.py
@@ -87,7 +87,51 @@ def _arrangement_ids_for(jset) -> list[str]:
     return out
 
 
-def _provider_body(p, sov_map, regimes, arr_map) -> str:
+def _data_practices_section(pid: str, name: str, dp_entry: dict | None) -> str:
+    """Advisory data-practices block: curated facts with cited sources, or an explicit
+    'not curated' statement. Never omitted silently for a provider page."""
+    e = lambda v: escape(str(v), quote=True)
+    parts = ['<h2>Data practices</h2>',
+             '<p class="axis">How does this provider treat the data you send it? Advisory'
+             ' statements about documented practices — not legal advice.</p>']
+    if not dp_entry:
+        parts.append(f"<p>Data practices are not curated for {e(name)} yet — no verified"
+                     " facts. Curation happens by hand via pull request.</p>")
+        return "\n".join(parts)
+
+    def cite(fact: str) -> str:
+        c = (dp_entry.get("citations") or {}).get(fact) or {}
+        if not c.get("url"):
+            return ""
+        loc = f" — {e(c['locator'])}" if c.get("locator") else ""
+        return (f' <a href="{e(c["url"])}">source</a>'
+                f"<small>{loc} (retrieved {e(c.get('retrieved', 'unavailable'))})</small>")
+
+    rows = []
+    td = dp_entry.get("training_default")
+    if td is not None:
+        label = {"yes": "Yes", "no": "No", "opt-out": "Opt-out available"}[td]
+        rows.append(("Trains on customer API data by default", f"<strong>{e(label)}</strong>"
+                     + cite("training_default")))
+    if dp_entry.get("retention") is not None:
+        rows.append(("Retention (API inputs/outputs)", e(dp_entry["retention"])
+                     + cite("retention")))
+    sub = dp_entry.get("subprocessors")
+    if sub:
+        rows.append(("Subprocessor list",
+                     f'<a href="{e(sub["url"])}">{e(sub["url"])}</a>'
+                     f"<small> — {e(sub['locator'])} (retrieved {e(sub['retrieved'])})</small>"))
+    if dp_entry.get("enterprise_tier") is not None:
+        rows.append(("Enterprise tier", e(dp_entry["enterprise_tier"])
+                     + cite("enterprise_tier")))
+    rows.append(("Entry last reviewed", e(dp_entry.get("reviewed", "unavailable"))))
+    parts.append("<table>")
+    parts += [f"<tr><th>{k}</th><td>{v}</td></tr>" for k, v in rows]
+    parts.append("</table>")
+    return "\n".join(parts)
+
+
+def _provider_body(p, sov_map, regimes, arr_map, dp_entry=None) -> str:
     e = lambda v: escape(str(v), quote=True)
     name = p["name"]
     j = p["jurisdiction"]
@@ -136,6 +180,7 @@ def _provider_body(p, sov_map, regimes, arr_map) -> str:
             "<table>"]
     body += [f"<tr><th>{k}</th><td>{v}</td></tr>" for k, v in rows]
     body.append("</table>")
+    body.append(_data_practices_section(p["id"], name, dp_entry))
     return "\n".join(body)
 
 
@@ -157,6 +202,7 @@ def build(out_dir: str) -> dict:
     prov = _load("provenance.json")
     regimes = _load("regimes.json")["regimes"]
     arrangements = {a["id"]: a for a in _load("arrangements.json")["arrangements"]}
+    data_practices = _load("data_practices.json")["entries"]
     e = lambda v: escape(str(v), quote=True)
     footer = (f"<p>Generated from the <a href=\"{REPO}\">borderlint</a> knowledge base — "
               f"providers reviewed {e(providers['updated'])}, sovereignty {e(sov['updated'])}, "
@@ -173,7 +219,8 @@ def build(out_dir: str) -> dict:
         title = f"{p['name']} data residency & sovereignty — {SITE_NAME}"
         desc = (f"AI data residency and sovereignty for {p['name']}: residency {jlabel}, "
                 f"sovereignty bloc {sov_map.get(p['id'], 'unknown')}. From the borderlint knowledge base.")
-        doc = _page(title, desc, _provider_body(p, sov_map, regimes, arrangements), depth=1, footer=footer)
+        doc = _page(title, desc, _provider_body(p, sov_map, regimes, arrangements,
+                                                data_practices.get(p["id"])), depth=1, footer=footer)
         with open(os.path.join(out_dir, "providers", f"{p['id']}.html"), "w", encoding="utf-8") as fh:
             fh.write(doc)
         plinks.append((p["name"], f"providers/{p['id']}.html"))

--- a/tests/test_borderlint.py
+++ b/tests/test_borderlint.py
@@ -2444,7 +2444,8 @@ def test_evidence_data_practices_register():
     pack = evidence([Finding(d1, "fail", [])], k, _pol(["hk"]))
     assert "## Data practices (advisory)" in pack and "not legal advice" in pack
     assert "Trains on customer API data by default: **no**" in pack
-    assert "[source](https://developers.openai.com/api/docs/guides/your-data" in pack
+    # the href is exactly the URL; locator + retrieval date stay outside the link
+    assert "[source](https://developers.openai.com/api/docs/guides/your-data)" in pack
     assert "retrieved 2026-08-21" in pack
     assert "reviewed 2026-08-21" in pack
     # verdicts untouched: register adds no summary or severity changes

--- a/tests/test_borderlint.py
+++ b/tests/test_borderlint.py
@@ -136,6 +136,16 @@ def _scan_file(content, suffix=".py"):
     return scan(p, kb)
 
 
+def _src(content, suffix=".py"):
+    """Write content to a temp file and return its path (for scan-into-kb2 flows)."""
+    import os
+    import tempfile
+    p = os.path.join(tempfile.mkdtemp(), "f" + suffix)
+    with open(p, "w", encoding="utf-8") as fh:
+        fh.write(content)
+    return p
+
+
 def dets(src):
     return _resolve_sovereignty(_scan_py("x.py", src, kb), kb)
 
@@ -465,6 +475,53 @@ def test_kb_drift_sdk_coverage():
         shipped = json.load(fh)
     kd.validate_suppression(shipped, {p["id"] for p in doc["providers"]})
     assert kd.sdk_coverage_gaps(doc["providers"], shipped) == []
+
+
+def test_kb_drift_data_practices():
+    kd = _drift()
+    today = dt.date(2026, 8, 21)
+    dp_doc = {"entries": {
+        "fresh": {"training_default": "no", "reviewed": "2026-08-01"},
+        "stale": {"training_default": "no", "reviewed": "2026-01-01"},
+        "nodate": {"training_default": "no"},
+    }}
+    # stale entry flagged with age; fresh not; missing date reported loudly
+    assert kd.data_practices_stale(dp_doc, today) == [("nodate", "missing date", -1),
+                                                      ("stale", "2026-01-01", 232)]
+    # gaps: ids only — no fact values ever leak into the report
+    providers = ["fresh", "stale", "uncovered", "exempt"]
+    supp = {"data_practices_exempt": {"exempt": "no public API terms"}}
+    assert kd.data_practices_gaps(providers, dp_doc, supp) == ["uncovered"]
+    assert kd.data_practices_gaps(providers, dp_doc) == ["exempt", "uncovered"]
+    # loud failures: exemption for an unknown id, exemption without a reason
+    for bad in ({"data_practices_exempt": {"ghost": "reason"}},
+                {"data_practices_exempt": {"fresh": "  "}}):
+        try:
+            kd.validate_suppression(bad, {"fresh"})
+            assert False, "expected ValueError"
+        except ValueError as e:
+            assert "ghost" in str(e) or "fresh" in str(e)
+    # report: both sections render, counts join the summary head, gap carries no facts
+    r = kd.render_report(dt.date(2026, 7, 20), [], [], [], [],
+                         dp_stale=[("openai", "2026-01-01", 201)],
+                         dp_gaps=["deepseek"])
+    assert "### Stale data-practice entries" in r and "`openai` — reviewed 2026-01-01, 201 days ago" in r
+    assert "### Data-practice gaps" in r and "- `deepseek`" in r
+    assert "Never auto-fill" in r
+    assert "1 stale data-practice entries · 1 data-practice gaps" in r
+    # empty sections omitted; empty report still renders nothing
+    empty = kd.render_report(dt.date(2026, 7, 20), [], [], [], [])
+    assert "### Stale data-practice entries" not in empty and "### Data-practice gaps" not in empty
+    # shipped state: seed entries are fresh and the flagship set is curated (gaps exist by
+    # design for the long tail, but the five seeded providers must never be flagged stale)
+    import json
+    with open("borderlint/data/data_practices.json", encoding="utf-8") as fh:
+        shipped_dp = json.load(fh)
+    with open("borderlint/data/providers.json", encoding="utf-8") as fh:
+        ids = [p["id"] for p in json.load(fh)["providers"]]
+    assert not kd.data_practices_stale(shipped_dp, dt.date.today())
+    assert {"openai", "anthropic", "google_gemini", "azure_openai", "aws_bedrock"} <= set(shipped_dp["entries"])
+    assert set(shipped_dp["entries"]) <= set(ids)
 
 
 def test_kb_has_iso_date():
@@ -2166,6 +2223,13 @@ def test_kb_site_generator(tmp_path):
     assert t(a) != t(b) and m(a) != m(b) and "OpenAI" in t(a)
     # cn-destination page names its regime and links the arrangement
     assert 'href="https://' in b and "PIPL" in b
+    # data-practices section: curated provider renders cited facts + disclaimer
+    assert "Data practices" in a and "not legal advice" in a
+    assert "Trains on customer API data by default" in a
+    assert '<a href="https://developers.openai.com/api/docs/guides/your-data">source</a>' in a
+    assert "(retrieved 2026-08-21)" in a
+    # uncurated provider states absence explicitly
+    assert "not curated for DeepSeek yet" in b
     # site tooling lives outside the shipped package
     assert not os.path.exists(os.path.join(root, "borderlint", "kb_site.py"))
 
@@ -2282,3 +2346,123 @@ def test_claude_plugin_manifests():
     with open(os.path.join(root, "integrations", "claude-code-skill.md"), encoding="utf-8") as fh:
         legacy = fh.read()
     assert "Run the scan first" not in legacy and "claude-plugin/skills/borderlint-check" in legacy
+
+
+# --- Data-practices knowledge base --------------------------------------------
+
+def _dp():
+    from borderlint.kb import load_data_practices
+    return load_data_practices()
+
+
+def test_data_practices_schema():
+    from borderlint import kb as kbmod
+    dp = _dp()
+    assert {"openai", "anthropic", "google_gemini", "azure_openai", "aws_bedrock"} <= set(dp)
+    for pid, entry in dp.items():
+        assert entry["training_default"] in ("yes", "no", "opt-out", None)
+        assert kbmod._iso_date(entry["reviewed"])
+    # every data-practices key is a real bundled provider id
+    with open("borderlint/data/providers.json", encoding="utf-8") as fh:
+        ids = {p["id"] for p in json.load(fh)["providers"]}
+    assert set(dp) <= ids
+    # every non-null fact carries a complete citation; citations name existing facts only.
+    # `subprocessors` is self-citing: its value IS the {url, locator, retrieved} object.
+    for pid, entry in dp.items():
+        facts = {k for k in ("training_default", "retention", "enterprise_tier")
+                 if entry.get(k) is not None}
+        cited = set(entry.get("citations", {}))
+        assert facts <= cited, f"{pid}: uncited facts {facts - cited}"
+        assert cited <= facts, f"{pid}: stray citations {cited - facts}"
+        if entry.get("subprocessors") is not None:
+            assert all(entry["subprocessors"].get(k)
+                       for k in ("url", "locator", "retrieved")), pid
+        for fact, cite in entry.get("citations", {}).items():
+            assert all(cite.get(k) for k in ("url", "locator", "retrieved")), (pid, fact)
+            assert cite["url"].startswith("https://")
+
+
+def test_data_practices_partial_entry_is_explicitly_unknown():
+    dp = _dp()
+    # partially curated entries record nulls — explicitly unknown, never guessed
+    assert dp["anthropic"]["retention"] is None
+    assert dp["aws_bedrock"]["training_default"] is None
+    assert dp["aws_bedrock"]["subprocessors"] is None
+
+
+def test_data_practices_loader_rejects_bad_entries():
+    from borderlint import kb as kbm
+    bad = [
+        {"openai": {"training_default": "maybe", "reviewed": "2026-08-21"}},
+        {"openai": {"training_default": "no", "reviewed": "21/08/2026"}},
+        {"openai": {"training_default": "no", "reviewed": "2026-08-21",
+                    "citations": {"retention": {"url": "https://x", "locator": "",
+                                                "retrieved": "2026-08-21"}}}},
+    ]
+    for entries in bad:
+        try:
+            kbm._validate_data_practices(entries)
+            assert False, f"expected ValueError for {entries}"
+        except ValueError as e:
+            assert "openai" in str(e)
+
+
+def test_data_practices_never_change_verdicts():
+    # same source scanned with and without curated entries → identical verdicts
+    from borderlint import kb as kbmod
+    from borderlint.detect import scan as scan_file
+    real_dp = kbmod.load_data_practices
+
+    def run(with_facts: bool):
+        kbmod.load_data_practices = (real_dp if with_facts else lambda: {})
+        try:
+            kb2 = load_kb()
+            dets = _resolve_sovereignty(scan_file(_src("import openai\n"), kb2), kb2)
+            findings = evaluate(dets, _pol(["hk"]), "customer-pii", kb2)
+            return [(f.detection.provider_id, f.severity) for f in findings]
+        finally:
+            kbmod.load_data_practices = real_dp
+
+    assert run(True) == run(False) == [("openai", "fail")]
+
+
+def test_data_practices_uncurated_provider_does_not_fail_scan():
+    # deepseek has no curated entry: detection still works and absence is visible
+    from borderlint.detect import scan as scan_file
+    kb2 = load_kb()
+    ds = scan_file(_src('u = "https://api.deepseek.com/v1"\n'), kb2)
+    assert any(d.provider_id == "deepseek" for d in ds)
+    assert "deepseek" not in kb2.data_practices
+
+
+def test_evidence_data_practices_register():
+    # curated provider: facts with citations + retrieval dates; disclaimer present
+    from borderlint.report import evidence
+    from borderlint.policy import Finding
+    k = load_kb()
+    d1 = _resolve_sovereignty(_scan_py("a.py", "import openai\n", k), k)[0]
+    pack = evidence([Finding(d1, "fail", [])], k, _pol(["hk"]))
+    assert "## Data practices (advisory)" in pack and "not legal advice" in pack
+    assert "Trains on customer API data by default: **no**" in pack
+    assert "[source](https://developers.openai.com/api/docs/guides/your-data" in pack
+    assert "retrieved 2026-08-21" in pack
+    assert "reviewed 2026-08-21" in pack
+    # verdicts untouched: register adds no summary or severity changes
+    assert "1 fail" in pack.split("## Summary")[1].splitlines()[2]
+
+
+def test_evidence_data_practices_register_uncurated_visible():
+    # uncurated provider appears as not curated rather than being omitted
+    from borderlint.report import evidence
+    from borderlint.policy import Finding
+    k = load_kb()
+    d1 = _resolve_sovereignty(_scan_py("b.py", 'u = "https://api.deepseek.com"\n', k), k)[0]
+    pack = evidence([Finding(d1, "fail", [])], k, _pol(["hk"]))
+    assert "**DeepSeek** — not curated" in pack
+
+
+def test_evidence_register_absent_without_findings():
+    # no flows → no register section at all (nothing to describe)
+    from borderlint.report import evidence
+    k = load_kb()
+    assert "Data practices" not in evidence([], k, None)


### PR DESCRIPTION
<!-- PR for /opsx change provider-data-practice-facts -->

## Summary

Privacy reviewers evaluating AI providers ask the same four questions first — does the provider
train on my API data by default, what is the retention window, where is the subprocessor list,
and does an enterprise tier change the answer — and today they dig each answer out of scattered
ToS pages. This change adds a bundled, hand-curated `data_practices.json` knowledge base answering
those questions for five flagship providers (OpenAI, Anthropic, Google Gemini, Azure OpenAI,
AWS Bedrock), where every fact carries a source URL + locator note + retrieval date verified
against primary documentation. The facts surface in two reviewer-facing places — a register in
the evidence pack and a section on KB-website provider pages — and the scheduled drift check now
flags stale entries and providers without coverage. Strictly advisory: verdicts, summary counts,
and exit codes are unchanged (tested); facts never influence detection or policy evaluation.

## Traceability

| Artifact | Reference |
|----------|-----------|
| Task (Jira) | N/A |
| OpenSpec change | `openspec/changes/provider-data-practice-facts/` |
| Spec deltas | ADDED `provider-data-practices` (5 requirements); ADDED `cli-and-reporting` (`Evidence pack data-practices register`); ADDED `kb-freshness` (`Data-practices staleness coverage`); ADDED `kb-website` (`Provider page data-practices section`) |

## Changes

- `borderlint/data/data_practices.json` (new): per-provider entries with `training_default`
  (`yes`/`no`/`opt-out`/null), free-text `retention`, self-citing `subprocessors` link,
  `enterprise_tier` note, per-entry ISO-8601 `reviewed` date, and per-fact citations.
  Undocumented facts are recorded as `null` (explicitly unknown) — Anthropic's retention window
  and Bedrock's training default are deliberately null because primary sources did not confirm them.
- `borderlint/kb.py`: `load_data_practices()` with loud validation (training vocabulary,
  ISO-8601 review date, complete `{url, locator, retrieved}` citations); exposed as
  `kb.data_practices`.
- `borderlint/report.py`: evidence pack gains an advisory "Data practices" register — curated
  facts with cited sources and retrieval dates; uncurated providers stay visible as "not curated".
- `scripts/kb_site.py`: provider pages gain a data-practices section with hyperlinked citations
  or an explicit "not curated yet" statement; disclaimer on every rendering.
- `scripts/kb_drift.py`: stale-entry and curation-gap sections joined to the summary head;
  gap records carry ids only, never fact values; new `data_practices_exempt` suppression key
  validated loudly (unknown id or empty reason raises).
- `CONTRIBUTING.md`: entry schema table and curation rules (cite primary sources, unknown means
  null, human curation only, 90-day review cadence).
- `tests/test_borderlint.py`: schema/citation tests, advisory-guarantee tests (verdicts identical
  with/without the KB), evidence-register scenarios, site page variants, drift staleness/gap/
  suppression cases including shipped-state assertions.

## Verification

- [x] `openspec validate provider-data-practice-facts --strict` passes
- [x] All tasks in tasks.md checked (15/15)
- [x] Tests covering each acceptance scenario (full suite: 174 passed)
- [x] Verification pass found and fixed one defect (locator prose leaked into citation hrefs);
      test tightened to assert the href is exactly the URL
