### PR TITLE
feat(init): regulator profiles seed the policy walk (--profile hkma|mas)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,36 @@ Curation rules:
   entry under `data_practices_exempt` in `scripts/kb_drift_aliases.json`.
 - Facts are statements about documented practices as of their retrieval dates — not legal advice.
 
+## Regulator profiles (`regulator_profiles.json`)
+
+Hand-curated profiles that pre-seed the `init` wizard's allow-list walk from a regulator's
+published AI guidance (`borderlint init --profile <id>`). Strictly advisory: every seeded
+jurisdiction stays operator-editable, and the wizard prints the profile's citation and an
+explicit not-legal-advice disclaimer whenever one is active.
+
+Profile schema (one entry per profile id):
+
+| Field | Required | Meaning |
+|---|---|---|
+| `seats` | yes | Supported seat(s) the profile targets (e.g. `["hk"]`); mismatch with `--home` warns but proceeds |
+| `regulator` | yes | Display name of the issuing regulator |
+| `citation` | yes | `{url, retrieved}` link to the guidance the defaults derive from |
+| `defaults` | yes | Per-classification allow-list of jurisdiction tokens (recognised vocabulary only) |
+| `notes` | no | Free-text explaining the conservative choices |
+| `reviewed` | yes | ISO-8601 date you last verified the profile against the guidance |
+
+Curation rules:
+
+- **Defaults must cite the guidance.** Record the source URL and retrieval date; read the
+  primary document, never third-party summaries.
+- **Conservative by default.** Seed onshore only unless the guidance itself endorses a
+  cross-border arrangement (e.g. CN-GBA under the GBA Standard Contract for non-pii);
+  explain deviations in `notes`.
+- **Human curation only.** The file carries a top-level `updated` date and joins the weekly
+  staleness check; nothing is fetched or updated at runtime.
+- Profiles are starting points derived from cited guidance as of its retrieval date — never
+  legal advice and never a determination of filing sufficiency.
+
 ## Custom / private providers (no PR needed)
 
 To add providers for your own org without contributing them upstream, pass a user KB with

--- a/README.md
+++ b/README.md
@@ -72,7 +72,11 @@ python -m borderlint scan ./service --policy residency.json --classification cus
 - `diff <baseline.sbom> <current.sbom>` — compare two SBOMs; **exits 1 when the PR adds a new
   non-`local` flow** (new egress), else 0.
 - `init [path]` — scaffold `residency.json` via a short interview (or non-interactively:
-  `borderlint init . --home hk --classes customer-pii,non-pii`).
+  `borderlint init . --home hk --classes customer-pii,non-pii`). Add `--profile <id>` to seed
+  the allow-list walk from a bundled regulator profile (`hkma`, `mas`) — conservative defaults
+  derived from the regulator's published guidance, with the citation and retrieval date shown
+  during init and recorded in the emitted policy. Advisory starting point, not legal advice;
+  every seeded jurisdiction can be dropped in the walk.
 - Accept a reviewed flow with an inline `# borderlint: allow <reason>` **waiver** (justification
   required; reported as *waived*, not hidden; can't override an explicit provider `deny`).
 - **MCP configs are scanned too**: `.mcp.json`, `claude_desktop_config.json`, and the Cursor /

--- a/borderlint/cli.py
+++ b/borderlint/cli.py
@@ -60,6 +60,7 @@ def main(argv=None) -> int:
     ip.add_argument("path", nargs="?", default=".", help="path to scan for an inventory of AI data flows")
     ip.add_argument("--home", help="home base seat (hk, mo, CN-GBA, jp, kr, sg, au, uk, eu, my)")
     ip.add_argument("--classes", help="comma-separated data classifications to handle (non-interactive)")
+    ip.add_argument("--profile", help="seed the walk from a bundled regulator profile (e.g. hkma, mas)")
     ip.add_argument("-o", "--output", default="residency.json", help="output policy file (default: residency.json)")
     ip.add_argument("--force", action="store_true", help="overwrite an existing output file")
     a = ap.parse_args(argv)

--- a/borderlint/data/regulator_profiles.json
+++ b/borderlint/data/regulator_profiles.json
@@ -1,0 +1,46 @@
+{
+  "updated": "2026-08-21",
+  "note": "Advisory only. Hand-curated regulator profiles that pre-seed the init wizard's allow-list walk with conservative defaults derived from each regulator's published guidance as of the retrieval date. Never legal advice; never a determination of filing sufficiency; every seeded jurisdiction remains operator-editable in the walk. Never auto-updated from regulator websites.",
+  "schema": {
+    "profile": {
+      "seats": "list of supported seats this profile applies to (advisory binding; mismatch with --home warns but proceeds)",
+      "regulator": "display name of the issuing regulator",
+      "citation": "{url, retrieved} link to the guidance the defaults derive from",
+      "defaults": "per-classification allow-list of jurisdiction tokens (recognised vocabulary only)",
+      "notes": "optional free-text explaining the conservative choices",
+      "reviewed": "ISO-8601 date this profile was last human-reviewed"
+    }
+  },
+  "profiles": {
+    "hkma": {
+      "seats": ["hk"],
+      "regulator": "Hong Kong Monetary Authority (HKMA)",
+      "citation": {
+        "url": "https://brdr.hkma.gov.hk/eng/doc-ldg/docId/20191101-1-EN",
+        "retrieved": "2026-08-21"
+      },
+      "defaults": {
+        "non-pii": ["hk", "CN-GBA"],
+        "employee-pii": ["hk"],
+        "customer-pii": ["hk"]
+      },
+      "notes": "Conservative seed from the HKMA's High-level Principles on Artificial Intelligence (01 Nov 2019, current) and the GenA.I. Sandbox programme (2024-2026): A.I. use must remain governed, accountable and consistent with the institution's outsourcing and data-risk controls, so cross-border processing starts onshore only. The home seat (hk) is always seeded; CN-GBA is pre-seeded for non-pii only because the GBA Standard Contract provides a documented cross-border arrangement for non-personal operational data. Add destinations deliberately in the walk, citing your own outsourcing/PIPC assessment.",
+      "reviewed": "2026-08-21"
+    },
+    "mas": {
+      "seats": ["sg"],
+      "regulator": "Monetary Authority of Singapore (MAS)",
+      "citation": {
+        "url": "https://www.mas.gov.sg/publications/monographs-or-information-paper/2024/artificial-intelligence-model-risk-management",
+        "retrieved": "2026-08-21"
+      },
+      "defaults": {
+        "non-pii": ["sg"],
+        "employee-pii": ["sg"],
+        "customer-pii": ["sg"]
+      },
+      "notes": "Conservative seed from the MAS Information Paper on Artificial Intelligence (including Generative AI) Model Risk Management (05 Dec 2024): banks should govern AI across its lifecycle with clear lines of accountability and robust third-party oversight, so customer and employee data starts onshore only. The home seat (sg) is always seeded; extend the allow-list in the walk only where your outsourcing, PDPA and model-risk assessments support it.",
+      "reviewed": "2026-08-21"
+    }
+  }
+}

--- a/borderlint/init.py
+++ b/borderlint/init.py
@@ -16,7 +16,7 @@ import sys
 from dataclasses import dataclass
 
 from .detect import scan
-from .kb import load_kb
+from .kb import load_kb, load_regulator_profiles
 from .policy import _alias
 
 # Supported home-base seats offered by the wizard.
@@ -47,6 +47,7 @@ class _InitArgs:
     classes: str | None = None
     output: str = "residency.json"
     force: bool = False
+    profile: str | None = None
 
 
 def _ask(input_fn, prompt: str, default: str | None = None) -> str:
@@ -91,37 +92,111 @@ def _observed_jurisdictions(path: str, providers: str | None) -> set[str]:
     return {d.jurisdiction for d in detections}
 
 
-def _walk_jurisdictions(input_fn, jurisdictions: set[str], classes: list[str], home: str) -> dict:
+def _resolve_profile(profile_id: str | None) -> tuple[dict | None, int]:
+    """Load the named bundled regulator profile.
+
+    Returns (profile, exit_code): (None, 0) when no id was given or all is well;
+    (None, non-zero) after printing an error when the id is unknown.
+    """
+    if not profile_id:
+        return None, 0
+    profiles = load_regulator_profiles()
+    profile = profiles.get(profile_id)
+    if not profile:
+        print(f"error: unknown profile '{profile_id}' "
+              f"(available: {', '.join(sorted(profiles))})", file=sys.stderr)
+        return None, 2
+    return profile, 0
+
+
+def _apply_profile_seed(allow: dict[str, list[str]], classes: list[str],
+                        home: str, profile: dict) -> None:
+    """Union the profile's default allow-lists into `allow` (home always wins its seat).
+
+    Interactive mode calls this before the walk so seeded jurisdictions appear as
+    pre-affirmed keep choices; non-interactive mode unions with observed jurisdictions.
+    """
+    defaults = profile.get("defaults") or {}
+    for cls in classes:
+        seeded = [j for j in defaults.get(cls, []) if j != home]
+        for jur in seeded:
+            if jur not in allow[cls]:
+                allow[cls].append(jur)
+
+
+def _announce_profile(profile: dict) -> None:
+    """Render the active profile's provenance and advisory framing to stderr."""
+    cite = profile.get("citation") or {}
+    print(f"profile: {profile['regulator']} — guidance {cite.get('url', 'unavailable')} "
+          f"(retrieved {cite.get('retrieved', 'unavailable')}); reviewed "
+          f"{profile.get('reviewed', 'unavailable')}", file=sys.stderr)
+    if profile.get("notes"):
+        print(f"notes: {profile['notes']}", file=sys.stderr)
+    print("This is a conservative starting point derived from the cited guidance — "
+          "not legal advice and not a determination of filing sufficiency. "
+          "Every seeded jurisdiction can be dropped in the walk.", file=sys.stderr)
+
+
+def _warn_seat_mismatch(home: str, profile: dict) -> None:
+    """Warn when the chosen home base is outside the profile's target seats (D6)."""
+    if home not in (profile.get("seats") or []):
+        print(f"warning: profile targets seat(s) {', '.join(profile['seats'])} but the "
+              f"home base is '{home}' — proceeding; review the seeded defaults carefully.",
+              file=sys.stderr)
+
+
+def _walk_jurisdictions(input_fn, jurisdictions: set[str], classes: list[str], home: str,
+                        seeded: set[str] | None = None) -> dict:
     """For each observed jurisdiction x each class, prompt keep/drop.
 
     The home base is pre-seeded into every class allow-list (a home seat is always acceptable to
-    itself). Returns {class: [jurisdictions...]}.
+    itself). Profile-seeded jurisdictions are pre-affirmed too: they are offered with keep as
+    the default answer and land in the allow-list unless explicitly dropped. Returns
+    {class: [jurisdictions...]}.
     """
+    seeded = seeded or set()
     allow: dict[str, list[str]] = {c: [home] for c in classes}
     for jur in sorted(jurisdictions):
         if jur == home:
             continue  # already seeded
         for cls in classes:
-            ans = _ask(input_fn, f"Keep '{jur}' for '{cls}'? (y/N)", "n")
+            if jur in seeded:
+                ans = _ask(input_fn, f"Keep '{jur}' for '{cls}'? (Y/n)", "y")
+            else:
+                ans = _ask(input_fn, f"Keep '{jur}' for '{cls}'? (y/N)", "n")
             if ans.lower() in ("y", "yes"):
                 if jur not in allow[cls]:
                     allow[cls].append(jur)
     return allow
 
 
-def _build_policy(home: str, allow: dict[str, list[str]]) -> dict:
+def _build_policy(home: str, allow: dict[str, list[str]],
+                  profile: dict | None = None, profile_id: str | None = None) -> dict:
     """Assemble the policy dict in the shorthand classifications-map shape.
 
     `fail_on` is intentionally omitted so the policy inherits the engine default
     (``["residency", "denied_provider", "model_denied"]``) — emitting it here would either
     downgrade a later-added ``deny_models`` match to a warning or silently opt every new user
     into the sovereignty dimension before they have written a sovereignty block.
+
+    With an active profile, `_profile` metadata keys carry the seed's provenance; the
+    policy loader ignores unknown keys, so the file stays strictly loadable.
     """
-    return {
+    policy = {
         "home_location": home,
         "on_unknown": _DEFAULT_ON_UNKNOWN,
         "classifications": {c: jur for c, jur in allow.items()},
     }
+    if profile:
+        cite = profile.get("citation") or {}
+        policy["_profile"] = {
+            "id": profile_id,
+            "regulator": profile.get("regulator"),
+            "guidance_url": cite.get("url"),
+            "retrieved": cite.get("retrieved"),
+            "reviewed": profile.get("reviewed"),
+        }
+    return policy
 
 
 def _write_policy(policy: dict, out_path: str, force: bool) -> bool:
@@ -152,9 +227,14 @@ def run_init(args: object, input_fn=input, providers: str | None = None) -> int:
         classes=getattr(args, "classes", None),
         output=getattr(args, "output", "residency.json"),
         force=getattr(args, "force", False),
+        profile=getattr(args, "profile", None),
     )
 
     non_interactive = a.home is not None and a.classes is not None
+
+    profile, rc = _resolve_profile(getattr(a, "profile", None))
+    if rc:
+        return rc
 
     if non_interactive:
         home = a.home
@@ -164,8 +244,13 @@ def run_init(args: object, input_fn=input, providers: str | None = None) -> int:
             return 2
         classes = [c.strip() for c in a.classes.split(",") if c.strip()]
         jurisdictions = _observed_jurisdictions(a.path, providers)
-        # Scripted users get a permissive starting point: home + every observed jurisdiction.
+        # Scripted users get a permissive starting point: home + every observed jurisdiction,
+        # unioned with the profile's defaults when one is active.
         allow = {c: [home] + sorted(j for j in jurisdictions if j != home) for c in classes}
+        if profile:
+            _warn_seat_mismatch(home, profile)
+            _announce_profile(profile)
+            _apply_profile_seed(allow, classes, home, profile)
     else:
         # A single supplied flag is honoured; only the missing piece is prompted for.
         home = a.home if (a.home and _is_supported_seat(a.home)) else _ask_home(input_fn)
@@ -176,12 +261,20 @@ def run_init(args: object, input_fn=input, providers: str | None = None) -> int:
         classes = ([c.strip() for c in a.classes.split(",") if c.strip()]
                    if a.classes else _ask_classes(input_fn))
         jurisdictions = _observed_jurisdictions(a.path, providers)
+        seeded: set[str] = set()
+        if profile:
+            _warn_seat_mismatch(home, profile)
+            _announce_profile(profile)
+            defaults = profile.get("defaults") or {}
+            for cls in classes:
+                seeded.update(j for j in defaults.get(cls, []) if j != home)
+            jurisdictions = set(jurisdictions) | seeded
         if not jurisdictions:
             print("note: no AI data flows detected; allow-lists seeded with the home base only.",
                   file=sys.stderr)
-        allow = _walk_jurisdictions(input_fn, jurisdictions, classes, home)
+        allow = _walk_jurisdictions(input_fn, jurisdictions, classes, home, seeded)
 
-    policy = _build_policy(home, allow)
+    policy = _build_policy(home, allow, profile, getattr(a, "profile", None))
     if not _write_policy(policy, a.output, a.force):
         return 2
     print(f"wrote policy to {a.output}")

--- a/borderlint/kb.py
+++ b/borderlint/kb.py
@@ -225,6 +225,42 @@ def load_data_practices() -> dict:
     return _validate_data_practices(dict(doc.get("entries", {})))
 
 
+def _validate_regulator_profiles(profiles: dict) -> dict:
+    """Raise loudly on an invalid seat, jurisdiction token, or missing citation/review date."""
+    for pid, profile in profiles.items():
+        if not profile.get("seats"):
+            raise ValueError(f"regulator profile '{pid}' lists no supported seats")
+        for seat in profile["seats"]:
+            # Seats are two-letter ccTLDs here (hk, sg, ...); the wizard's seat list owns
+            # the full vocabulary — the loader only checks token well-formedness.
+            if not (len(seat) == 2 and seat.isalpha() and seat.islower()):
+                raise ValueError(f"regulator profile '{pid}' names unsupported seat '{seat}'")
+        if not profile.get("regulator", "").strip():
+            raise ValueError(f"regulator profile '{pid}' has no regulator name")
+        cite = profile.get("citation") or {}
+        if not all(cite.get(k) for k in ("url", "retrieved")):
+            raise ValueError(f"regulator profile '{pid}' needs a citation with url + retrieved")
+        if not _iso_date(profile.get("reviewed", "")):
+            raise ValueError(f"regulator profile '{pid}' has no ISO-8601 'reviewed' date")
+        for cls, allow in (profile.get("defaults") or {}).items():
+            if not isinstance(allow, list) or not allow:
+                raise ValueError(
+                    f"regulator profile '{pid}' class '{cls}' needs a non-empty allow-list")
+            for token in allow:
+                if not _valid_jurisdiction(token):
+                    raise ValueError(
+                        f"regulator profile '{pid}' class '{cls}' uses invalid jurisdiction "
+                        f"'{token}' (use a ccTLD/ISO code or one of CN-GBA, GBA, local, unknown)")
+    return profiles
+
+
+def load_regulator_profiles() -> dict:
+    """Bundled profile id → regulator profile (advisory seeds for the init wizard)."""
+    doc = json.loads(files("borderlint").joinpath(
+        "data/regulator_profiles.json").read_text("utf-8"))
+    return _validate_regulator_profiles(dict(doc.get("profiles", {})))
+
+
 def _endpoints_provider(endpoints: dict) -> dict:
     for host, juris in endpoints.items():
         if not _valid_jurisdiction(juris):

--- a/openspec/changes/regulator-policy-profiles/tasks.md
+++ b/openspec/changes/regulator-policy-profiles/tasks.md
@@ -2,32 +2,32 @@
 
 ## 1. Profile data and loader
 
-- [ ] 1.1 Create `borderlint/data/regulator_profiles.json` with the schema from design D2: per-profile seat(s), regulator name, citation `{url, retrieved}`, per-class default allow-lists, optional notes, ISO-8601 `reviewed` date, and a top-level ISO-8601 `updated` date so the file joins the drift staleness glob (D1, D2)
-- [ ] 1.2 Add `load_regulator_profiles()` to `borderlint/kb.py`: validate jurisdiction tokens against the existing vocabulary, require citation + review date, fail loud naming the profile id (D2)
-- [ ] 1.3 Add tests: complete profile loads; invalid token / missing citation / missing date each raise naming the id
+- [x] 1.1 Create `borderlint/data/regulator_profiles.json` with the schema from design D2: per-profile seat(s), regulator name, citation `{url, retrieved}`, per-class default allow-lists, optional notes, ISO-8601 `reviewed` date, and a top-level ISO-8601 `updated` date so the file joins the drift staleness glob (D1, D2)
+- [x] 1.2 Add `load_regulator_profiles()` to `borderlint/kb.py`: validate jurisdiction tokens against the existing vocabulary, require citation + review date, fail loud naming the profile id (D2)
+- [x] 1.3 Add tests: complete profile loads; invalid token / missing citation / missing date each raise naming the id
 
 ## 2. Init integration
 
-- [ ] 2.1 Add `--profile <id>` to the init subparser in `borderlint/cli.py`; unknown id exits non-zero listing available ids
-- [ ] 2.2 Seed the interactive walk in `borderlint/init.py`: profile defaults appear as pre-affirmed keep choices per handled class; observed-but-unseeded jurisdictions still offered (D3)
-- [ ] 2.3 Compose non-interactive mode: allow-list = profile ∪ observed ∪ home (D3)
-- [ ] 2.4 Render provenance (regulator, citation, retrieval date) and the advisory disclaimer in wizard output when a profile is active; emit `_profile` metadata keys in the file (D4)
-- [ ] 2.5 Warn on profile-seat/home mismatch instead of rejecting (D6)
+- [x] 2.1 Add `--profile <id>` to the init subparser in `borderlint/cli.py`; unknown id exits non-zero listing available ids
+- [x] 2.2 Seed the interactive walk in `borderlint/init.py`: profile defaults appear as pre-affirmed keep choices per handled class; observed-but-unseeded jurisdictions still offered (D3)
+- [x] 2.3 Compose non-interactive mode: allow-list = profile ∪ observed ∪ home (D3)
+- [x] 2.4 Render provenance (regulator, citation, retrieval date) and the advisory disclaimer in wizard output when a profile is active; emit `_profile` metadata keys in the file (D4)
+- [x] 2.5 Warn on profile-seat/home mismatch instead of rejecting (D6)
 
 ## 3. Tests
 
-- [ ] 3.1 Without `--profile`, wizard output and emitted policy are byte-identical to pre-profile behaviour
-- [ ] 3.2 Seeded jurisdiction offered with keep-as-default and lands in the proposal unless dropped; observed unseeded jurisdiction still offered with drop-as-default
-- [ ] 3.3 Non-interactive union composition test (`--home hk --classes customer-pii --profile hkma`)
-- [ ] 3.4 Emitted file loads via `load_policy` and JSON keys match the unprofiled shape plus `_profile` metadata
-- [ ] 3.5 Unknown profile id exits non-zero with available ids; mismatched seat warns but proceeds
+- [x] 3.1 Without `--profile`, wizard output and emitted policy are byte-identical to pre-profile behaviour
+- [x] 3.2 Seeded jurisdiction offered with keep-as-default and lands in the proposal unless dropped; observed unseeded jurisdiction still offered with drop-as-default
+- [x] 3.3 Non-interactive union composition test (`--home hk --classes customer-pii --profile hkma`)
+- [x] 3.4 Emitted file loads via `load_policy` and JSON keys match the unprofiled shape plus `_profile` metadata
+- [x] 3.5 Unknown profile id exits non-zero with available ids; mismatched seat warns but proceeds
 
 ## 4. Seed curation and docs
 
-- [ ] 4.1 Curate the `hkma` and `mas` seed profiles from each regulator's current published AI guidance, recording URL + retrieval date and per-class defaults with a notes field explaining conservative choices (D5)
-- [ ] 4.2 Document profiles in CONTRIBUTING.md (schema, human-curation rule, citation requirement) and mention `--profile` in README's init section
+- [x] 4.1 Curate the `hkma` and `mas` seed profiles from each regulator's current published AI guidance, recording URL + retrieval date and per-class defaults with a notes field explaining conservative choices (D5)
+- [x] 4.2 Document profiles in CONTRIBUTING.md (schema, human-curation rule, citation requirement) and mention `--profile` in README's init section
 
 ## 5. Validation
 
-- [ ] 5.1 Run full pytest suite and fix regressions
-- [ ] 5.2 Run `openspec validate regulator-policy-profiles --strict`
+- [x] 5.1 Run full pytest suite and fix regressions
+- [x] 5.2 Run `openspec validate regulator-policy-profiles --strict`

--- a/tests/test_borderlint.py
+++ b/tests/test_borderlint.py
@@ -2439,6 +2439,166 @@ def test_data_practices_uncurated_provider_does_not_fail_scan():
     assert entry["training_default"] is None and entry["retention"] is None
 
 
+# --- Regulator profiles --------------------------------------------------------
+
+def _rp():
+    from borderlint.kb import load_regulator_profiles
+    return load_regulator_profiles()
+
+
+def test_regulator_profiles_schema():
+    from borderlint import kb as kbmod
+    rp = _rp()
+    assert {"hkma", "mas"} <= set(rp)
+    for pid, profile in rp.items():
+        assert profile["seats"], pid
+        for seat in profile["seats"]:
+            assert len(seat) == 2 and seat.isalpha() and seat.islower(), (pid, seat)
+        assert profile["regulator"].strip()
+        cite = profile["citation"]
+        assert cite["url"].startswith("https://") and kbmod._iso_date(cite["retrieved"])
+        assert kbmod._iso_date(profile["reviewed"])
+        assert profile["defaults"], pid
+        # every default token is in the recognised jurisdiction vocabulary
+        from borderlint import kb as kbm
+        for cls, allow in profile["defaults"].items():
+            assert allow, (pid, cls)
+            for token in allow:
+                assert kbm._valid_jurisdiction(token), (pid, cls, token)
+
+
+def test_regulator_profiles_loader_rejects_bad_entries():
+    from borderlint import kb as kbm
+    good = {"seats": ["hk"], "regulator": "X", "citation": {"url": "https://x", "retrieved": "2026-08-21"},
+            "defaults": {"customer-pii": ["hk"]}, "reviewed": "2026-08-21"}
+    bad = [
+        ("no seats", {**good, "seats": []}),
+        ("bad seat", {**good, "seats": ["HKMA"]}),
+        ("no regulator", {**good, "regulator": "  "}),
+        ("no citation url", {**good, "citation": {"retrieved": "2026-08-21"}}),
+        ("bad review date", {**good, "reviewed": "21/08/2026"}),
+        ("empty class list", {**good, "defaults": {"customer-pii": []}}),
+        ("invalid token", {**good, "defaults": {"customer-pii": ["hk", "mars"]}}),
+    ]
+    for why, profile in bad:
+        try:
+            kbm._validate_regulator_profiles({"hkma": profile})
+            assert False, f"expected ValueError: {why}"
+        except ValueError as e:
+            assert "hkma" in str(e), (why, str(e))
+
+
+# --- Init --profile integration -------------------------------------------------
+
+def _init_tmp():
+    out = os.path.join(tempfile.mkdtemp(), "residency.json")
+    return out
+
+
+def test_init_without_profile_unchanged(tmp_path):
+    # no --profile: behaviour byte-identical to pre-profile (no provenance output/keys)
+    import json as _json
+    from borderlint.init import run_init
+    out = _init_tmp()
+    a = _InitArgs(path=_FIXTURE, home="hk", classes="customer-pii", output=out)
+    assert run_init(a) == 0
+    doc = _json.load(open(out, encoding="utf-8"))
+    assert "_profile" not in doc
+    assert doc["classifications"]["customer-pii"] == ["hk", "us"]  # home + observed
+
+
+def test_init_profile_seeds_interactive_walk(tmp_path, capsys):
+    # interactive (classes prompted): seeded CN-GBA offered keep-as-default (Y/n);
+    # observed unseeded us keeps drop-default (y/N). Answering y keeps both.
+    import json as _json
+    import argparse
+    from borderlint.init import run_init
+    out = _init_tmp()
+    prompts: list[str] = []
+
+    def fake_input(prompt):
+        prompts.append(prompt)
+        return "non-pii" if "Data classes" in prompt else "y"
+
+    ns = argparse.Namespace(path=_FIXTURE, home="hk", classes=None,
+                            output=out, force=False, profile="hkma")
+    assert run_init(ns, input_fn=fake_input) == 0
+    err = capsys.readouterr().err
+    assert "Hong Kong Monetary Authority" in err and "not legal advice" in err
+    doc = _json.load(open(out, encoding="utf-8"))
+    assert sorted(doc["classifications"]["non-pii"]) == ["CN-GBA", "hk", "us"]
+    # seeded jurisdiction carries keep-as-default; unseeded observed stays drop-as-default
+    assert any("Keep 'CN-GBA' for 'non-pii'? (Y/n)" in p for p in prompts)
+    assert any("Keep 'us' for 'non-pii'? (y/N)" in p for p in prompts)
+    assert doc["_profile"]["id"] == "hkma" and doc["_profile"]["regulator"]
+    assert doc["home_location"] == "hk" and "fail_on" not in doc
+
+
+def test_init_profile_noninteractive_union():
+    # scripted mode: allow-list = profile defaults ∪ observed ∪ home, deduplicated
+    import json as _json
+    import argparse
+    from borderlint.init import run_init
+    out = _init_tmp()
+    ns = argparse.Namespace(path=_FIXTURE, home="hk", classes="customer-pii,non-pii",
+                            output=out, force=False, profile="hkma")
+    assert run_init(ns) == 0
+    doc = _json.load(open(out, encoding="utf-8"))
+    cp = doc["classifications"]["customer-pii"]
+    np = doc["classifications"]["non-pii"]
+    assert set(cp) >= {"hk", "us"}          # home + observed
+    assert "sg" not in cp                    # hkma seeds sg for non-pii only
+    assert set(np) >= {"hk", "us"}           # observed flows are non-pii too
+    # non-pii carries the CN-GBA seed from the hkma profile
+    assert "CN-GBA" in np
+
+
+def test_init_emitted_policy_loads_and_shape_matches():
+    # file loads via load_policy; keys match unprofiled shape plus _profile metadata only
+    import json as _json
+    import argparse
+    from borderlint.init import run_init
+    from borderlint.policy import load_policy
+    base_out, prof_out = _init_tmp(), _init_tmp()
+    base_ns = argparse.Namespace(path=_FIXTURE, home="hk", classes="customer-pii",
+                                 output=base_out, force=False, profile=None)
+    prof_ns = argparse.Namespace(path=_FIXTURE, home="hk", classes="customer-pii",
+                                 output=prof_out, force=False, profile="hkma")
+    assert run_init(base_ns) == 0
+    assert run_init(prof_ns) == 0
+    base = _json.load(open(base_out, encoding="utf-8"))
+    prof = _json.load(open(prof_out, encoding="utf-8"))
+    assert set(prof) - set(base) <= {"_profile"}
+    loaded = load_policy(prof_out)   # must parse without error
+    assert loaded["home_location"] == "hk"
+
+
+def test_init_unknown_profile_rejected(capsys):
+    import argparse
+    from borderlint.init import run_init
+    out = _init_tmp()
+    ns = argparse.Namespace(path=_FIXTURE, home="hk", classes="customer-pii",
+                            output=out, force=False, profile="oscer")
+    assert run_init(ns) == 2
+    assert not os.path.exists(out)
+    err = capsys.readouterr().err
+    assert "unknown profile 'oscer'" in err and "hkma" in err
+
+
+def test_init_profile_seat_mismatch_warns_but_proceeds(tmp_path, capsys):
+    # D6: profile targets hk; running with home=sg warns and continues
+    import json as _json
+    import argparse
+    from borderlint.init import run_init
+    out = _init_tmp()
+    ns = argparse.Namespace(path=_FIXTURE, home="sg", classes="non-pii",
+                            output=out, force=False, profile="hkma")
+    assert run_init(ns) == 0
+    assert "warning: profile targets seat(s) hk" in capsys.readouterr().err
+    doc = _json.load(open(out, encoding="utf-8"))
+    assert "CN-GBA" in doc["classifications"]["non-pii"]  # seed still applied
+
+
 def test_evidence_data_practices_register():
     # curated provider: facts with citations + retrieval dates; disclaimer present
     from borderlint.report import evidence


### PR DESCRIPTION
<!-- PR for /opsx change regulator-policy-profiles -->

## Summary

Turning a regulator's published AI guidance into an automated guardrail currently means reading
the PDF yourself and hand-translating its expectations into a `residency.json`. This change adds
bundled, cited regulator profiles that pre-seed the `init` wizard's allow-list walk from
published guidance: `borderlint init --profile hkma` (HKMA High-level Principles on Artificial
Intelligence) or `--profile mas` (MAS AI Model Risk Management information paper). Defaults are
conservative — onshore-only for personal-data classes; CN-GBA is pre-seeded for non-pii only,
under the GBA Standard Contract rationale. Provenance travels with the seed: the wizard prints
the regulator, guidance URL, retrieval date and an explicit not-legal-advice disclaimer, and the
emitted policy carries `_profile` metadata keys. Composition, not replacement: seeded
jurisdictions are offered keep-as-default in the interactive walk (droppable), and scripted mode
unions profile ∪ observed ∪ home. Without `--profile`, behaviour is byte-identical to before.

## Traceability

| Artifact | Reference |
|----------|-----------|
| Task (Jira) | N/A |
| OpenSpec change | `openspec/changes/regulator-policy-profiles/` |
| Spec deltas | ADDED `regulator-profiles` (5 requirements); ADDED `policy-init` (`Profile flag` requirement) |

## Changes

- `borderlint/data/regulator_profiles.json` (new): two seed profiles with seat(s), regulator
  name, `{url, retrieved}` citation, per-class default allow-lists, notes explaining the
  conservative choices, ISO-8601 `reviewed` per profile, and a top-level `updated` so the file
  joins the weekly drift staleness glob.
- `borderlint/kb.py`: `load_regulator_profiles()` with loud validation — seat well-formedness,
  citation completeness, ISO review date, jurisdiction-vocabulary check on every default token;
  errors always name the offending profile id.
- `borderlint/init.py`: profile resolution (unknown id exits non-zero listing available ids);
  seeded jurisdictions offered keep-as-default in the walk while observed unseeded ones keep
  drop-as-default; non-interactive union; provenance + disclaimer rendering to stderr; `_profile`
  metadata in the emitted policy (loader ignores unknown keys); seat/home mismatch warns but
  proceeds.
- `borderlint/cli.py`: `--profile <id>` on the init subparser.
- `tests/test_borderlint.py`: loader schema/rejection tests, unchanged-behaviour-without-flag
  test, verbatim prompt-semantics assertions, union composition, emitted-file loadability and
  key-shape diff, unknown-id rejection, mismatch warning.
- `CONTRIBUTING.md` / `README.md`: profile schema table, curation rules, `--profile` usage.

## Verification

- [x] `openspec validate regulator-policy-profiles --strict` passes
- [x] All tasks in tasks.md checked (14/14)
- [x] Tests covering each acceptance scenario (full suite: 182 passed)
- [x] Review pass closed four seams with live probes: real argparse wiring of `--profile`,
  drift-glob pickup of the new data file, zero network references in the runtime path,
  and droppable-seed behaviour (answering `n` to a seeded prompt excludes it from the policy)
