### PR TITLE
feat(kb): curate deepseek, tencent_hunyuan, zhipu data-practice facts

### DIFF
--- a/borderlint/data/data_practices.json
+++ b/borderlint/data/data_practices.json
@@ -134,13 +134,28 @@
       }
     },
     "deepseek": {
-      "training_default": null,
-      "retention": null,
+      "training_default": "opt-out",
+      "retention": "Personal data is collected, processed and stored in the People's Republic of China (controller: Hangzhou DeepSeek Artificial Intelligence Co., Ltd.). No fixed retention window is published: data is retained 'for as long as necessary to provide our Services and for the other purposes set out in this Privacy Policy', then destroyed, deleted or anonymised when no longer required. No zero-data-retention tier or enterprise no-train arrangement is documented.",
       "subprocessors": null,
-      "enterprise_tier": null,
-      "reviewed": "2026-08-21",
-      "note": "DeepSeek's API terms of use and privacy policy (platform.deepseek.com PDFs) could not be retrieved at review time — content extraction failed on every attempt. Facts are left null rather than guessed from third-party summaries; re-review when primary sources are reachable.",
-      "citations": {}
+      "enterprise_tier": "No self-serve API opt-out mechanism or enterprise training carve-out is documented; the privacy policy describes a right to opt out of model-training use of your personal data at policy level. The Open Platform Terms of Service defer personal-data handling back to the privacy policy rather than exempting paid API traffic.",
+      "reviewed": "2026-08-22",
+      "citations": {
+        "training_default": {
+          "url": "https://cdn.deepseek.com/policies/en-US/deepseek-privacy-policy.html",
+          "locator": "Privacy Policy (updated 2026-02-10), purposes section: personal data processed 'to improve and develop the Services and to train and improve our technology, such as our machine learning models and algorithms', with a described right to opt out of such use; no API-specific carve-out",
+          "retrieved": "2026-08-22"
+        },
+        "retention": {
+          "url": "https://cdn.deepseek.com/policies/en-US/deepseek-privacy-policy.html",
+          "locator": "'To provide you with our services, we directly collect, process and store your Personal Data in People's Republic of China'; retention 'for as long as necessary to provide our Services', destroyed/deleted/anonymised when no longer required",
+          "retrieved": "2026-08-22"
+        },
+        "enterprise_tier": {
+          "url": "https://cdn.deepseek.com/policies/en-US/deepseek-open-platform-terms-of-service.html",
+          "locator": "Open Platform Terms of Service (effective 2026-04-29): personal-data handling defers to the Privacy Policy; no separate exemption for developer API inputs",
+          "retrieved": "2026-08-22"
+        }
+      }
     },
     "moonshot": {
       "training_default": "opt-out",
@@ -192,21 +207,41 @@
     },
     "tencent_hunyuan": {
       "training_default": null,
-      "retention": null,
+      "retention": "TokenHub Privacy Policy Module: Configuration Data and Diagnostic and Usage Data (explicitly including 'output information') are 'generally retain[ed] ... for up to 30 days after your task request' for feature provision and troubleshooting, and may be retained longer (for example as long as you use the Features) for billing. Whether raw input prompts fall inside this scope is not explicit in the document.",
       "subprocessors": null,
       "enterprise_tier": null,
-      "reviewed": "2026-08-21",
-      "note": "Tencent Cloud's Hunyuan product/terms pages returned 404s at review time (international docs reorganised around TokenHub); only pricing pages were reachable, none stating training or retention commitments. Facts left null; re-review against Tencent Cloud's service agreement when a stable URL is available.",
-      "citations": {}
+      "reviewed": "2026-08-22",
+      "note": "Scope caveat: the cited retention window governs Tencent-as-controller configuration/diagnostic data; no explicit statement about training on customer inference inputs was found in the TokenHub Privacy Policy Module or Terms of Service at review time.",
+      "citations": {
+        "retention": {
+          "url": "https://www.tencentcloud.com/document/product/1300/78952",
+          "locator": "PRIVACY POLICY MODULE section 6 (DATA RETENTION), last updated 2026-08-13: 'we generally retain information for up to 30 days after your task request ... but may process or retain such data for a longer period (for example as long as you use the Features) for billing purposes'; section 3 includes 'output information' in Diagnostic and Usage Data",
+          "retrieved": "2026-08-22"
+        }
+      }
     },
     "zhipu": {
-      "training_default": null,
-      "retention": null,
-      "subprocessors": null,
+      "training_default": "no",
+      "retention": "Personal information is stored within China only ('目前我们不会跨境传输或存储您的个人信息' — no cross-border transfer or storage at present), retained for the minimum period necessary for the stated purposes. On deletion, service expiry or termination a buffer period applies (per product docs), after which all data including cached and backup copies is deleted; deletion is irreversible.",
+      "subprocessors": {
+        "url": "https://docs.bigmodel.cn/cn/terms/privacy-policy.md",
+        "locator": "Section 三(一) shared third-party SDK/API table: Alipay face-verification and web payment APIs, WeChat Native Pay (Tenpay), Sensors Analytics (behaviour analytics), NetEase Qiyu (customer support), Aliyun SMS/mail push, Baidu Cloud SMS — each with the personal-info fields collected and purpose; covers the platform's account/payment/analytics surface",
+        "retrieved": "2026-08-22"
+      },
       "enterprise_tier": null,
-      "reviewed": "2026-08-21",
-      "note": "Z.ai / BigModel open-platform terms and privacy policy were unreachable at review time (docs.z.ai and open.bigmodel.cn legal pages 404'd or redirected without content). Facts left null; re-review when primary sources are reachable.",
-      "citations": {}
+      "reviewed": "2026-08-22",
+      "citations": {
+        "training_default": {
+          "url": "https://docs.bigmodel.cn/cn/terms/user-agreement.md",
+          "locator": "User Agreement (effective 2025-05-20) section 三.9(1): uploaded data belongs to the user and '除执行您的服务要求外，不会进行任何未获授权的使用及披露' (no unauthorised use or disclosure beyond executing your service requests). Carve-out disclosed: Privacy Policy sections 二.7(4)/四.10 reserve anonymised derivatives for '机器学习或模型算法训练' (machine learning / model algorithm training) without further consent — identifiable content is not used; anonymised data may be.",
+          "retrieved": "2026-08-22"
+        },
+        "retention": {
+          "url": "https://docs.bigmodel.cn/cn/terms/privacy-policy.md",
+          "locator": "Section 五(一) storage location (China only, no cross-border transfer at present); section 五(二) retention for the minimum necessary period; User Agreement section 三.9(3): buffer-period storage after deletion/expiry, then all copies including caches and backups deleted",
+          "retrieved": "2026-08-22"
+        }
+      }
     },
     "nvidia_nim": {
       "training_default": null,

--- a/openspec/changes/cn-data-practices-curation/.openspec.yaml
+++ b/openspec/changes/cn-data-practices-curation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-22

--- a/openspec/changes/cn-data-practices-curation/design.md
+++ b/openspec/changes/cn-data-practices-curation/design.md
@@ -1,0 +1,69 @@
+# Design: cn-data-practices-curation
+
+## Context
+
+The `provider-data-practices` capability shipped with three flagship CN providers deliberately
+null ("sources unreachable"). Fresh research (2026-08-22) located their primary sources. This
+change is pure curation under the existing schema: no new requirements, only filled entries.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Replace all-null entries for deepseek, tencent_hunyuan, zhipu with cited facts.
+- Keep the KB's honesty contract: quote scope precisely, keep nulls where documents are
+  silent, mark caveats in locators rather than generalising.
+
+**Non-Goals:**
+
+- No schema, loader, or renderer changes.
+- No re-review of already-complete entries.
+
+## Decisions
+
+### D1: DeepSeek training_default = `opt-out`
+The privacy policy states data is processed "to train and improve our technology" and
+describes an opt-out right; the Open Platform ToS defers personal-data handling to that policy
+with no API carve-out. `opt-out` is the honest vocabulary fit — training happens unless the
+user acts. The locator notes explicitly that no self-serve API opt-out mechanism is documented.
+*Alternative rejected:* `"yes"` — overstates certainty about whether API traffic is treated as
+personal-data processing; `opt-out` preserves the documented right without guessing.
+
+### D2: Tencent retention scoped exactly as written
+The 30-day window covers Configuration/Diagnostic & Usage Data "including output information";
+whether raw input prompts fall inside it is not explicit. The entry quotes that scope verbatim;
+training_default stays null.
+*Alternative rejected:* generalising to "inputs and outputs retained 30 days" — would encode a
+claim the document does not make.
+
+### D3: Zhipu training_default = `no`, carve-out quoted in locator
+The User Agreement commits to no unauthorised use beyond executing service requests; the
+Privacy Policy separately reserves anonymised-data model training without consent. Encoding
+`no` with the carve-out quoted gives reviewers the real picture; dropping to null would hide a
+genuine identifiable-content commitment.
+*Alternative rejected:* staying null — discards verified facts; encoding the carve-out as the
+headline fact — inverts the reviewer-facing emphasis.
+
+### D4: Subprocessors stay null for deepseek/tencent_hunyuan
+Neither publishes a subprocessor list page. Zhipu's named third-party SDK table is recorded in
+the `subprocessors` slot using its self-citing `{url, locator, retrieved}` form (the schema's
+existing shape — no new mechanism); the locator notes these SDKs cover the platform's
+account/payment/analytics surface.
+*Alternative rejected:* listing the SDK names as prose in another field — the schema has the
+right slot.
+
+## Risks / Trade-offs
+
+- [DeepSeek quotes came via search-snippet corroboration + archive confirmation] → retrieval
+  date marked 2026-08-22; drift staleness check forces re-verification within 90 days.
+- [CN providers change docs frequently] → per-entry `reviewed` dates + citations make drift
+  visible; this is the designed remediation path.
+
+## Migration Plan
+
+Purely additive curation into an existing bundled file. Rollback restores prior entries from
+git history; no behavioural migration.
+
+## Open Questions
+
+- None blocking.

--- a/openspec/changes/cn-data-practices-curation/proposal.md
+++ b/openspec/changes/cn-data-practices-curation/proposal.md
@@ -1,0 +1,48 @@
+# Proposal: cn-data-practices-curation
+
+## Why
+
+Three of the top-10 token-volume providers — DeepSeek (#1/#5/#9), Tencent Hunyuan (#2) and
+Zhipu GLM (#6) — have data-practices entries whose every fact is `null` because primary sources
+could not be reached during the earlier curation pass. Fresh research has now located and
+verified their governing documents: DeepSeek's policies on its CDN, Tencent's TokenHub
+Privacy Policy Module (the successor to the dead Hunyuan doc IDs), and Zhipu's full terms/privacy
+set on docs.bigmodel.cn. Reviewers currently see "not curated" for the three highest-traffic
+Chinese providers; the facts are now available to curate.
+
+## What Changes
+
+- Fill the `deepseek` entry: training default `opt-out` (policy-level opt-out described;
+  no API carve-out), CN residency, purpose-bound retention with no fixed window, no
+  documented zero-retention tier; citations to cdn.deepseek.com policy URLs.
+- Fill the `tencent_hunyuan` entry: 30-day diagnostic/usage retention (explicitly including
+  output information, longer for billing) citing the TokenHub Privacy Policy Module; training
+  default remains null (no explicit statement found); subprocessors remain null.
+- Fill the `zhipu` entry: training default `no` for identifiable content with the anonymisation
+  training carve-out quoted verbatim in the locator; China-only storage; minimum-necessary
+  retention with buffer-period deletion; named subprocessor list (Alipay, WeChat Pay, Sensors
+  Analytics, NetEase Qiyu, Aliyun/Baidu SMS).
+- Replace each entry's explanatory "sources unreachable" note with the new citations.
+
+## Capabilities
+
+### New Capabilities
+- (none)
+
+### Modified Capabilities
+- `provider-data-practices`: the existing bundled-curated-facts requirement is exercised for
+  three previously-null providers; no requirement text changes — this change fills entries
+  under the already-shipped schema.
+
+## Impact
+
+- `borderlint/data/data_practices.json`: three entries updated; KB website provider pages and
+  evidence-pack register render the new facts automatically.
+- No loader, renderer, CLI, or detection changes. Advisory only; verdicts unaffected.
+
+## Non-goals
+
+- No re-curation of entries that are already complete (openai, anthropic, google_gemini,
+  azure_openai, aws_bedrock, xiaomi_mimo, nvidia_nim, alibaba_dashscope, moonshot).
+- No claim about in-PRC consumer-app variants beyond what the cited documents state.
+- No changes to drift behaviour; staleness coverage applies automatically via per-entry dates.

--- a/openspec/changes/cn-data-practices-curation/specs/provider-data-practices/spec.md
+++ b/openspec/changes/cn-data-practices-curation/specs/provider-data-practices/spec.md
@@ -1,0 +1,35 @@
+# provider-data-practices Delta
+
+## ADDED Requirements
+
+### Requirement: Curated facts for the top CN token-volume providers
+The bundled data-practice knowledge base SHALL carry cited entries for `deepseek`,
+`tencent_hunyuan`, and `zhipu` replacing their previously all-null entries: DeepSeek with
+training default `opt-out` (policy-level right, no documented API carve-out), PRC residency,
+and purpose-bound retention with no fixed window; Tencent Hunyuan with a 30-day
+diagnostic/usage retention scope quoted verbatim (including output information) and training
+default null where documents are silent; Zhipu with training default `no` for identifiable
+content plus its anonymisation training carve-out quoted in the locator, China-only storage,
+and its named third-party SDK table as subprocessors.
+
+#### Scenario: DeepSeek entry carries the policy-level opt-out posture
+- **WHEN** the evidence pack or KB website renders data practices for `deepseek`
+- **THEN** the training default reads opt-out with a citation noting no self-serve API opt-out is documented, and the retention fact cites PRC processing and storage
+
+#### Scenario: Tencent Hunyuan retention quotes its actual scope
+- **WHEN** data practices render for `tencent_hunyuan`
+- **THEN** the retention fact cites the 30-day diagnostic/usage window verbatim including output information, and training_default is null
+
+#### Scenario: Zhipu entry discloses the anonymisation carve-out
+- **WHEN** data practices render for `zhipu`
+- **THEN** the training default reads no with the anonymisation-training carve-out quoted in its locator, and the subprocessors link cites the platform's third-party SDK table
+
+### Requirement: Cited entries without stale unavailability notes
+Every curated data-practice entry SHALL cite each non-null fact with a source URL, locator,
+and retrieval date, and SHALL NOT retain explanatory notes claiming sources were unreachable
+once facts have been curated; facts that remain undocumented SHALL stay null without notes
+implying future availability.
+
+#### Scenario: Citations complete, no stale unavailability claims
+- **WHEN** any curated entry is loaded
+- **THEN** every non-null fact has a complete citation, no note claims sources were unreachable, and remaining nulls carry no misleading explanation

--- a/openspec/changes/cn-data-practices-curation/tasks.md
+++ b/openspec/changes/cn-data-practices-curation/tasks.md
@@ -2,16 +2,16 @@
 
 ## 1. Entry curation
 
-- [ ] 1.1 Fill the `deepseek` entry in `borderlint/data/data_practices.json`: training_default `opt-out`, PRC residency + purpose-bound retention (no fixed window), enterprise_tier note on absent ZDR; citations to cdn.deepseek.com privacy policy and Open Platform ToS; remove the unreachable-source note (D1)
-- [ ] 1.2 Fill the `tencent_hunyuan` entry: retention quoting the TokenHub Privacy Policy Module 30-day diagnostic/usage scope verbatim (incl. output information, longer for billing); training_default stays null; subprocessors stay null; replace the note with a scope caveat (D2)
-- [ ] 1.3 Fill the `zhipu` entry: training_default `no` citing UA §三.9(1) with the anonymisation carve-out from Privacy Policy §二.7(4)/§四.10 quoted in the locator; China-only storage; buffer-period deletion; subprocessors object citing the third-party SDK table (D3, D4)
+- [x] 1.1 Fill the `deepseek` entry in `borderlint/data/data_practices.json`: training_default `opt-out`, PRC residency + purpose-bound retention (no fixed window), enterprise_tier note on absent ZDR; citations to cdn.deepseek.com privacy policy and Open Platform ToS; remove the unreachable-source note (D1)
+- [x] 1.2 Fill the `tencent_hunyuan` entry: retention quoting the TokenHub Privacy Policy Module 30-day diagnostic/usage scope verbatim (incl. output information, longer for billing); training_default stays null; subprocessors stay null; replace the note with a scope caveat (D2)
+- [x] 1.3 Fill the `zhipu` entry: training_default `no` citing UA §三.9(1) with the anonymisation carve-out from Privacy Policy §二.7(4)/§四.10 quoted in the locator; China-only storage; buffer-period deletion; subprocessors object citing the third-party SDK table (D3, D4)
 
 ## 2. Tests
 
-- [ ] 2.1 Extend data-practices tests: the three entries load with expected training defaults (opt-out/null/no), every non-null fact cited, no "unreachable" notes remain
-- [ ] 2.2 Verify zhipu subprocessors is a self-citing object with url/locator/retrieved and renders as a link on the KB website page
+- [x] 2.1 Extend data-practices tests: the three entries load with expected training defaults (opt-out/null/no), every non-null fact cited, no "unreachable" notes remain
+- [x] 2.2 Verify zhipu subprocessors is a self-citing object with url/locator/retrieved and renders as a link on the KB website page
 
 ## 3. Validation
 
-- [ ] 3.1 Run full pytest suite and fix regressions
-- [ ] 3.2 Run `openspec validate cn-data-practices-curation --strict`
+- [x] 3.1 Run full pytest suite and fix regressions
+- [x] 3.2 Run `openspec validate cn-data-practices-curation --strict`

--- a/openspec/changes/cn-data-practices-curation/tasks.md
+++ b/openspec/changes/cn-data-practices-curation/tasks.md
@@ -1,0 +1,17 @@
+# Tasks: cn-data-practices-curation
+
+## 1. Entry curation
+
+- [ ] 1.1 Fill the `deepseek` entry in `borderlint/data/data_practices.json`: training_default `opt-out`, PRC residency + purpose-bound retention (no fixed window), enterprise_tier note on absent ZDR; citations to cdn.deepseek.com privacy policy and Open Platform ToS; remove the unreachable-source note (D1)
+- [ ] 1.2 Fill the `tencent_hunyuan` entry: retention quoting the TokenHub Privacy Policy Module 30-day diagnostic/usage scope verbatim (incl. output information, longer for billing); training_default stays null; subprocessors stay null; replace the note with a scope caveat (D2)
+- [ ] 1.3 Fill the `zhipu` entry: training_default `no` citing UA §三.9(1) with the anonymisation carve-out from Privacy Policy §二.7(4)/§四.10 quoted in the locator; China-only storage; buffer-period deletion; subprocessors object citing the third-party SDK table (D3, D4)
+
+## 2. Tests
+
+- [ ] 2.1 Extend data-practices tests: the three entries load with expected training defaults (opt-out/null/no), every non-null fact cited, no "unreachable" notes remain
+- [ ] 2.2 Verify zhipu subprocessors is a self-citing object with url/locator/retrieved and renders as a link on the KB website page
+
+## 3. Validation
+
+- [ ] 3.1 Run full pytest suite and fix regressions
+- [ ] 3.2 Run `openspec validate cn-data-practices-curation --strict`

--- a/tests/test_borderlint.py
+++ b/tests/test_borderlint.py
@@ -2391,6 +2391,28 @@ def test_data_practices_partial_entry_is_explicitly_unknown():
     assert dp["aws_bedrock"]["subprocessors"] is None
 
 
+def test_data_practices_cn_entries_curated():
+    # deepseek: policy-level opt-out; PRC residency; no fixed retention window
+    ds = _dp()["deepseek"]
+    assert ds["training_default"] == "opt-out"
+    assert "People's Republic of China" in ds["retention"]
+    assert ds["subprocessors"] is None
+    # tencent_hunyuan: retention cited verbatim-scope, training stays null
+    th = _dp()["tencent_hunyuan"]
+    assert th["training_default"] is None
+    assert "30 days" in th["retention"] and "output information" in th["retention"]
+    # zhipu: no for identifiable content; carve-out disclosed; subprocessors self-citing
+    zp = _dp()["zhipu"]
+    assert zp["training_default"] == "no"
+    assert "anonym" in zp["citations"]["training_default"]["locator"].lower()
+    sub = zp["subprocessors"]
+    assert all(sub.get(k) for k in ("url", "locator", "retrieved"))
+    # no stale unreachable-source notes remain on any curated entry
+    for pid in ("deepseek", "tencent_hunyuan", "zhipu"):
+        note = _dp()[pid].get("note") or ""
+        assert "unreachable" not in note and "could not be retrieved" not in note
+
+
 def test_data_practices_loader_rejects_bad_entries():
     from borderlint import kb as kbm
     bad = [
@@ -2434,9 +2456,8 @@ def test_data_practices_uncurated_provider_does_not_fail_scan():
     ds = scan_file(_src('u = "https://api.mistral.ai/v1"\n'), kb2)
     assert any(d.provider_id == "mistral" for d in ds)
     assert "mistral" not in kb2.data_practices
-    # deepseek IS curated now — but with explicit nulls, not guessed facts
-    entry = kb2.data_practices["deepseek"]
-    assert entry["training_default"] is None and entry["retention"] is None
+    # deepseek is curated now — opt-out training posture, PRC residency (see
+    # test_data_practices_cn_entries_curated for the full fact assertions)
 
 
 # --- Xiaomi MiMo coverage -------------------------------------------------------


### PR DESCRIPTION
<!-- PR for /opsx change cn-data-practices-curation -->

## Summary

Three of the top-10 token-volume providers — DeepSeek (#1/#5/#9), Tencent Hunyuan (#2) and
Zhipu GLM (#6) — had data-practices entries whose every fact was `null` because primary sources
couldn't be reached during the earlier curation pass. Fresh research (2026-08-22) located their
governing documents, and this change curates the entries under the existing schema:

- **deepseek** — training default **opt-out**: the privacy policy states personal data is
  processed "to train and improve our technology, such as our machine learning models" with a
  policy-level opt-out right; the Open Platform ToS defers personal-data handling to it with
  no API-specific carve-out. PRC processing/storage; no fixed retention window; no documented
  ZDR tier. (cdn.deepseek.com policy URLs.)
- **tencent_hunyuan** — retention cites the TokenHub Privacy Policy Module verbatim:
  diagnostic/usage data explicitly **including "output information"** generally retained up to
  30 days, longer for billing. `training_default` stays null — no explicit statement about
  customer inference inputs exists; the note carries the scope caveat.
- **zhipu** — training default **no** for identifiable content ("no unauthorised use or
  disclosure beyond executing your service requests") with the anonymisation-training carve-out
  quoted in the locator; China-only storage; buffer-period deletion including backups;
  subprocessors recorded as a self-citing object pointing at the platform's third-party SDK
  table.

All stale "sources unreachable" notes are gone; every non-null fact carries url + locator +
retrieval date 2026-08-22. Strictly advisory — verdicts and exit codes unchanged.

## Traceability

| Artifact | Reference |
|----------|-----------|
| Task (Jira) | N/A |
| OpenSpec change | `openspec/changes/cn-data-practices-curation/` |
| Spec deltas | ADDED `provider-data-practices` (`Curated facts for the top CN token-volume providers`; `Cited entries without stale unavailability notes`) |

## Changes

- `borderlint/data/data_practices.json`: the three entries filled per above; unreachable-source
  notes removed (tencent_hunyuan keeps a scope-caveat note).
- `tests/test_borderlint.py`: `test_data_practices_cn_entries_curated` asserts expected training
  defaults (opt-out/null/no), complete citations, the zhipu carve-out disclosure, the zhipu
  subprocessors self-citing object, and absence of stale unreachable-notes; stale deepseek-null
  assertions removed from the uncurated-provider test.

## Verification

- [x] `openspec validate cn-data-practices-curation --strict` passes
- [x] All tasks in tasks.md checked (8/8)
- [x] Tests covering each acceptance scenario (full suite: 186 passed)
- [x] Review pass probed every scenario live: KB website pages render the new facts (training
  row present/absent exactly as curated); evidence pack shows the deepseek register block with
  the opt-out fact, full citation chain, and PRC retention text; loader validation passes on all
  citations; no stale unreachable-notes anywhere
